### PR TITLE
Alpha 3.0.0/Added ability to turn heating on and off with an hardware switch

### DIFF
--- a/src/powerswitchvoid.h
+++ b/src/powerswitchvoid.h
@@ -5,7 +5,7 @@
  */
 
 /**
- * @brief Digtalswitch OR Read analog input pin for POWER SWITCH
+ * @brief Digtalswitch input pin for POWER SWITCH
  */
 
 int lastpowerswitchTrigger = LOW;                   // the previous reading from the input pin

--- a/src/powerswitchvoid.h
+++ b/src/powerswitchvoid.h
@@ -1,0 +1,59 @@
+/**
+ * @file powerswitchvoid.h
+ *
+ * @brief
+ */
+
+/**
+ * @brief Digtalswitch OR Read analog input pin for POWER SWITCH
+ */
+
+int lastpowerswitchTrigger = LOW;                   // the previous reading from the input pin
+int buttonStatePowerTrigger;                        // the current reading from the input pin
+unsigned long lastDebounceTimePowerTrigger = 0;     // the last time the output pin was toggled
+unsigned long debounceDelayPowerTrigger = 50;       // the debounce time; increase if the output flickers
+
+void checkpowerswitch() {
+    #if POWERSWITCHTYPE == 1
+        // Set pidON to 1 when powerswitch is HIGH
+        if (digitalRead(PINPOWERSWITCH) == HIGH) {
+            pidON = 1;
+        } else {
+            // Set pidON to 0 when powerswitch is not HIGH
+            pidON = 0;
+        }
+    #endif
+
+    #if POWERSWITCHTYPE == 2  // TRIGGER
+        int reading = digitalRead(PINPOWERSWITCH);
+
+        if (reading != lastpowerswitchTrigger) {
+            // reset the debouncing timer
+            lastDebounceTimePowerTrigger = millis();
+        }
+
+        if ((millis() - lastDebounceTimePowerTrigger) > debounceDelayPowerTrigger) {
+            // whatever the reading is at, it's been there for longer than the debounce
+            // delay, so take it as the actual current state:
+
+            // if the button state has changed:
+            if (reading != buttonStatePowerTrigger) {
+                buttonStatePowerTrigger = reading;
+
+                // only toggle heating power if the new button state is HIGH
+                if (buttonStatePowerTrigger == HIGH) {
+                    if (pidON == 0) {
+                        Serial.println("Turn Heating ON");
+                        pidON = 1;
+                    } else {
+                        Serial.println("Turn Heating OFF");
+                        pidON = 0;
+                    }
+                }
+            }
+        }
+
+        lastpowerswitchTrigger = reading;
+
+    #endif
+}

--- a/src/rancilio-pid.cpp
+++ b/src/rancilio-pid.cpp
@@ -793,6 +793,7 @@ void refreshTemp() {
 
 
 #include "brewvoid.h"
+#include "powerswitchvoid.h"
 #include "scalevoid.h"
 
 /**
@@ -1111,7 +1112,7 @@ void brewdetection() {
                     }
 
                     const unsigned long minBrewDurationForSteamModeQM_ON = 50;
-                    if (brewSteamDetectedQM == 1 && millis()-timePVStoON > minBrewDurationForSteamModeQM_ON) 
+                    if (brewSteamDetectedQM == 1 && millis()-timePVStoON > minBrewDurationForSteamModeQM_ON)
                     {
 
                         if (pvs == VoltageSensorOFF) {
@@ -1959,6 +1960,11 @@ void setup() {
         pinMode(PINVOLTAGESENSOR, PINMODEVOLTAGESENSOR);
         }
 
+        // IF POWERSWITCH is connected
+        if (POWERSWITCHTYPE > 0) {
+            pinMode(PINPOWERSWITCH, INPUT);
+        }
+
         // IF PINBREWSWITCH & Steam selected
         if (PINBREWSWITCH > 0) {
             #if (defined(ESP8266) && PINBREWSWITCH == 16)
@@ -2266,6 +2272,7 @@ void looppid() {
     brew();          // start brewing if button pressed
     checkSteamON();  // check for steam
     setEmergencyStopTemp();
+    checkpowerswitch();
     sendToBlynkMQTT();
     machinestatevoid();      // calc machinestate
     setchecklastpoweroff();  // FOR AP MODE
@@ -2430,7 +2437,7 @@ void setSteamMode(int steamMode) {
 
 void setPidStatus(int pidStatus) {
     pidON = pidStatus;
-     writeSysParamsToBlynk();
+    writeSysParamsToBlynk();
 }
 
 /**

--- a/src/userConfig_sample.h
+++ b/src/userConfig_sample.h
@@ -56,6 +56,7 @@ enum MACHINE {
 #define BREWMODE 1                 // 1 = NORMAL preinfusion ; 2 = Scale with weight
 #define BREWDETECTION 1            // 0 = off, 1 = Software (Onlypid 1), 2 = Hardware (Onlypid 0), 3 = Sensor/Hardware for Only PID
 #define BREWSWITCHTYPE 1           // 1 = normal Switch, 2 = Trigger Switch
+#define POWERSWITCHTYPE 2          // 0 = no switch connected, 1 = normal Switch, 2 = Trigger Switch
 #define COLDSTART_PID 1            // 1 = default coldstart values, 2 = custom values via blynk (expert mode activated)
 #define TRIGGERTYPE HIGH           // LOW = low trigger, HIGH = high trigger relay
 #define VOLTAGESENSORTYPE HIGH     // BREWDETECTION 3 configuration
@@ -154,6 +155,7 @@ enum MACHINE {
 // Pin Layout
 #define ONE_WIRE_BUS 2             // Temp sensor pin
 #define PINPRESSURESENSOR 99       // Pressuresensor 0: A0 (ESP8266), >0 ONLY ESP32
+#define PINPOWERSWITCH 99          // Input pin for powerswitch (use a pin which is LOW on startup or use an pull down resistor)
 #define PINVALVE 12                // Output pin for 3-way-valve
 #define PINPUMP 13                 // Output pin for pump
 #define PINHEATER 14               // Output pin for heater


### PR DESCRIPTION
This feature was tested on my Rancilio Silvia (both trigger and classic switch) and it works with my esp8266.
It currently only supports inputs with integrated or external pull-down resistors.

If you looking forward to merge this feature, I am willing to update the documentation.