### PR TITLE
Pull include of userConfig.h forward

### DIFF
--- a/src/rancilio-pid.cpp
+++ b/src/rancilio-pid.cpp
@@ -12,6 +12,9 @@
 #define FW_HOTFIX     0
 #define FW_BRANCH     "MASTER"
 
+// User Config
+#include "userConfig.h"         // needs to be configured by the user
+
 // Libraries
 #include <ArduinoOTA.h>
 #if TOF == 1
@@ -34,7 +37,6 @@
 #include "Storage.h"
 #include "ISR.h"
 #include "debugSerial.h"
-#include "userConfig.h"         // needs to be configured by the user
 #include "rancilio-pid.h"
 
 #if defined(ESP32)


### PR DESCRIPTION
To fix build issues due to TOF and TEMPSENSOR being undefined, the include of userConfig.h is pulled forward.

This fixes #284 and fixes #278.