### PR TITLE
Pin dependency versions, revert WiFi config changes

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -5,20 +5,20 @@ extra_configs = platformio_extra.ini
 
 [env]
 lib_deps =
-    lebuni/ZACwire for TSic @ ^2.0.0
-    schm1tz1/TSIC @ ^1.1.2
-    milesburton/DallasTemperature @ ^3.11.0
-    paulstoffregen/OneWire @ ^2.3.7
-    adafruit/Adafruit_VL53L0X @ ^1.2.0
-    olkal/HX711_ADC @ ^1.2.12
-    olikraus/U8g2 @ ^2.34.3
+    lebuni/ZACwire for TSic @ 2.0.0
+    schm1tz1/TSIC @ 1.1.2
+    milesburton/DallasTemperature @ 3.11.0
+    paulstoffregen/OneWire @ 2.3.7
+    adafruit/Adafruit_VL53L0X @ 1.2.0
+    olkal/HX711_ADC @ 1.2.12
+    olikraus/U8g2 @ 2.34.5
     git+https://github.com/rancilio-pid/Arduino-PID-Library
-    knolleary/PubSubClient @ ^2.8
-    me-no-dev/AsyncTCP @ ^1.1.1
-    bblanchon/ArduinoJson @ ^6.19
+    knolleary/PubSubClient @ 2.8.0
+    me-no-dev/AsyncTCP @ 1.1.1
+    bblanchon/ArduinoJson @ 6.19.4
     tobiasschuerg/ESP8266 Influxdb @ 3.9.0
-    git+https://github.com/me-no-dev/ESPAsyncWebServer
-    git+https://github.com/tzapu/WiFiManager
+    git+https://github.com/me-no-dev/ESPAsyncWebServer#f71e3d4
+    git+https://github.com/tzapu/WiFiManager#71937d1
 
 [env:nodemcuv2_usb]
 platform = espressif8266 @^2.6.3

--- a/src/RancilioServer.h
+++ b/src/RancilioServer.h
@@ -412,7 +412,7 @@ void serverSetup() {
 
         } else if (request->method() == 1) {  //WebRequestMethod enum -> HTTP_GET
             //return all params as json
-            DynamicJsonDocument doc(JSON_ARRAY_SIZE(1) + JSON_OBJECT_SIZE(9+1) * EDITABLE_VARS_LEN);
+            DynamicJsonDocument doc(4096); //JSON_ARRAY_SIZE(1) + JSON_OBJECT_SIZE(9+1) * EDITABLE_VARS_LEN);
 
             //get parameter id from frst parameter, e.g. /parameters?param=PID_ON
             int paramCount = request->params();

--- a/src/RancilioServer.h
+++ b/src/RancilioServer.h
@@ -335,9 +335,10 @@ void serverSetup() {
         if (request->method() == 2) {   //returns values from WebRequestMethod enum -> 2 == HTTP_POST
             //update all given params and match var name in editableVars
             int params = request->params();
-            String m = "Got ";
+            /*String m = "Got ";
             m += params;
             m += " request parameters: <br />";
+            */
 
             for (int i = 0 ; i < params; i++) {
                 AsyncWebParameter* p = request->getParam(i);
@@ -353,21 +354,23 @@ void serverSetup() {
                         continue;
                     }
 
+                    /*
                     m += "Setting ";
                     m += e.displayName;
                     m += " from ";
+                    */
 
                     if (e.type == kInteger) {
-                        m += *(int *)e.ptr;
+                        //m += *(int *)e.ptr;
 
                         int newVal = atoi(p->value().c_str());
                         *(int *)e.ptr = newVal;
                     } else if (e.type == kUInt8) {
-                        m += *(uint8_t *)e.ptr;
+                        //m += *(uint8_t *)e.ptr;
 
                         *(uint8_t *)e.ptr = (uint8_t)atoi(p->value().c_str());
                     } else if (e.type == kDouble || e.type == kDoubletime) {
-                        m += *(double *)e.ptr;
+                        //m += *(double *)e.ptr;
 
                         float newVal = atof(p->value().c_str());
                         *(double *)e.ptr = newVal;
@@ -386,14 +389,14 @@ void serverSetup() {
                         e.ptr = (void *)newVal;
                     }*/
 
-                    m += " to ";
+                    /*m += " to ";
                     m += p->value();
 
-                    m += "<br/>";
+                    m += "<br/>";*/
                 }
             }
 
-            request->send(200, "text/html", m);
+            request->send(200, "text/html", "Parameters saved");
 
             // Write to EEPROM
             if (writeToEeprom) {

--- a/src/rancilio-pid.cpp
+++ b/src/rancilio-pid.cpp
@@ -1582,12 +1582,12 @@ void tempLed() {
  * @brief Set up internal WiFi hardware
  */
 void wiFiSetup() {
-    //wm.setCleanConnect(true);
+    wm.setCleanConnect(true);
     wm.setConfigPortalTimeout(60); // sec Timeout for Portal
     wm.setConnectTimeout(5); // Try 5 sec to connect to WLAN
     wm.setBreakAfterConfig(true);
-    wm.setConnectRetries(5);
-    wm.setWiFiAutoReconnect(true);
+    //wm.setConnectRetries(5);
+    //wm.setWiFiAutoReconnect(true);
     wm.setHostname(hostname);
 
     if (wm.autoConnect(hostname, pass)) {

--- a/src/rancilio-pid.cpp
+++ b/src/rancilio-pid.cpp
@@ -1582,11 +1582,11 @@ void tempLed() {
  * @brief Set up internal WiFi hardware
  */
 void wiFiSetup() {
-    wm.setCleanConnect(true);
+    //wm.setCleanConnect(true);
     wm.setConfigPortalTimeout(60); // sec Timeout for Portal
     wm.setConnectTimeout(5); // Try 5 sec to connect to WLAN
     wm.setBreakAfterConfig(true);
-    //wm.setConnectRetries(5);
+    wm.setConnectRetries(3);
     //wm.setWiFiAutoReconnect(true);
     wm.setHostname(hostname);
 

--- a/src/rancilio-pid.cpp
+++ b/src/rancilio-pid.cpp
@@ -596,14 +596,14 @@ void refreshTemp() {
             temperature = sensors.getTempCByIndex(0);
         #endif
 
-            if (machineState != kSteam) {
-                temperature -= brewTempOffset;
-            }
-
             if (!checkSensor(temperature) && movingAverageInitialized) {
                 temperature = previousInput;
                 return; // if sensor data is not valid, abort function; Sensor must
                         // be read at least one time at system startup
+            }
+
+            if (machineState != kSteam) {
+                temperature -= brewTempOffset;
             }
 
             if (brewDetectionMode == 1) {
@@ -630,14 +630,14 @@ void refreshTemp() {
         #endif
     #endif
 
-            if (machineState != kSteam) {
-                temperature -= brewTempOffset;
-            }
-
             if (!checkSensor(temperature) && movingAverageInitialized) {
                 temperature = previousInput;
                 return; // if sensor data is not valid, abort function; Sensor must
                         // be read at least one time at system startup
+            }
+
+            if (machineState != kSteam) {
+                temperature -= brewTempOffset;
             }
 
             if (brewDetectionMode == 1) {


### PR DESCRIPTION
* Pin library dependencies to current versions so users always get the same ones
* revert WiFi initialization changes from various-fixes branch
* don't create full text answer when saving parameters