### PR TITLE
Add ToF sensor data/water level to MQTT

### DIFF
--- a/src/Displaytemplatestandard.h
+++ b/src/Displaytemplatestandard.h
@@ -162,7 +162,7 @@ void printScreen()
         }
 
     #if TOF == 1
-        u8g2.setCursor(100, 2);
+        u8g2.setCursor(105, 1);
         u8g2.printf("%.0f\n", percentage);   //display water level
         u8g2.print((char)37);
     #endif

--- a/src/rancilio-pid.cpp
+++ b/src/rancilio-pid.cpp
@@ -2363,6 +2363,11 @@ void writeSysParamsToMQTT(void) {
         #if BREWMODE == 2
             mqtt_publish("weightSetpoint", number2string(weightSetpoint));
         #endif
+
+        #if TOF == 1
+            mqtt_publish("waterLevelDistance", number2string(distance));
+            mqtt_publish("waterLevelPercentage", number2string(percentage));
+        #endif
         }
     }
 }


### PR DESCRIPTION
Water level was not published via MQTT.

I also re-positioned the water level percentage on the display. It was 1 pixel lower than the MQTT string and touched the MQTT string horizontally. So I moved it up by 1 pixel and to the right by 5 pixel.

Before:

![image](https://user-images.githubusercontent.com/6548690/210213923-88a60f28-82d9-49dd-ae2e-e9ee17bf0791.png)

After:

![image](https://user-images.githubusercontent.com/6548690/210213724-e36559dc-6116-48a6-a1c5-15cdb3f0d920.png)
