### PR TITLE
fix crash while setup wifi via wifi manager

### DIFF
--- a/src/rancilio-pid.cpp
+++ b/src/rancilio-pid.cpp
@@ -1611,9 +1611,9 @@ void wiFiSetup() {
     } else {
         debugPrintln("WiFi connection timed out...");
 
-        #if OLED_DISPLAY != 0
-            displayLogo(langstring_nowifi[0], langstring_nowifi[1]);
-        #endif
+       // #if OLED_DISPLAY != 0
+       //     displayLogo(langstring_nowifi[0], langstring_nowifi[1]);
+       // #endif
 
         wm.disconnect();
         delay(1000);
@@ -1621,9 +1621,9 @@ void wiFiSetup() {
         offlineMode = 1;
     }
 
-    #if OLED_DISPLAY != 0
-        displayLogo(langstring_connectwifi1, wm.getWiFiSSID(true));
-    #endif
+    // #if OLED_DISPLAY != 0
+    //    displayLogo(langstring_connectwifi1, wm.getWiFiSSID(true));
+    // #endif
 
     startRemoteSerialServer();
 }
@@ -1813,15 +1813,7 @@ void setup() {
         pinMode(PINSTEAMSWITCH, INPUT_PULLDOWN);
     #endif
 
-    #if OLED_DISPLAY != 0
-        u8g2.setI2CAddress(oled_i2c * 2);
-        u8g2.begin();
-        u8g2_prepare();
-        displayLogo(String("Version ") + String(sysVersion), "");
-       // delay(2000); // caused crash with wifi manager
-    #endif
-
-    // Init Scale by BREWMODE 2 or SHOTTIMER 2
+        // Init Scale by BREWMODE 2 or SHOTTIMER 2
     #if (BREWMODE == 2 || ONLYPIDSCALE == 1)
         initScale();
     #endif
@@ -1923,6 +1915,16 @@ void setup() {
     setupDone = true;
 
     enableTimer1();
+    // Display has to be init in the end, because ESP8266 crash during wifi manager setup. 
+    #if OLED_DISPLAY != 0
+        u8g2.setI2CAddress(oled_i2c * 2);
+        u8g2.begin();
+        u8g2_prepare();
+        displayLogo(String("Version ") + String(sysVersion), "");
+       // delay(2000); // caused crash with wifi manager
+    #endif
+
+
 }
 
 void loop() {


### PR DESCRIPTION
Wifi manager crash with ESP8266 because of the further display initialization.
PR should solve it. Display initialization in the end of the setup().