### PR TITLE
Move MQTT Indicator

### DIFF
--- a/src/Displaytemplatescale.h
+++ b/src/Displaytemplatescale.h
@@ -102,7 +102,7 @@ void printScreen() {
         // draw box
         u8g2.drawFrame(0, 0, 128, 64);
 
-        // Für Statusinfos
+        // For status info
         u8g2.drawFrame(32, 0, 128, 12);
 
         if (offlineMode == 0) {
@@ -123,11 +123,11 @@ void printScreen() {
 
             if (MQTT == 1) {
                 if (mqtt.connected() == 1) {
-                    u8g2.setCursor(77, 1);
+                    u8g2.setCursor(60, 1);
                     u8g2.setFont(u8g2_font_profont11_tf);
                     u8g2.print("MQTT");
                 } else {
-                    u8g2.setCursor(77, 2);
+                    u8g2.setCursor(60, 2);
                     u8g2.print("");
                 }
             }

--- a/src/Displaytemplatestandard.h
+++ b/src/Displaytemplatestandard.h
@@ -147,11 +147,11 @@ void printScreen()
 
             if (MQTT == 1) {
                 if (mqtt.connected() == 1) {
-                    u8g2.setCursor(77, 1);
+                    u8g2.setCursor(60, 1);
                     u8g2.setFont(u8g2_font_profont11_tf);
                     u8g2.print("MQTT");
                 } else {
-                    u8g2.setCursor(77, 2);
+                    u8g2.setCursor(60, 2);
                     u8g2.print("");
                 }
             }

--- a/src/Displaytemplatetemponly.h
+++ b/src/Displaytemplatetemponly.h
@@ -50,7 +50,7 @@ void printScreen() {
             }
         }
 
-        // Für Statusinfos
+        // For status info
         if (offlineMode == 0) {
             getSignalStrength();
 

--- a/src/Displaytemplateupright.h
+++ b/src/Displaytemplateupright.h
@@ -106,7 +106,7 @@ void printScreen() {
 
             u8g2.print(" s");
 
-            // Für Statusinfos
+            // For status info
             u8g2.drawFrame(0, 0, 64, 12);
 
             if (offlineMode == 0) {
@@ -127,11 +127,11 @@ void printScreen() {
 
                 if (MQTT == 1) {
                     if (mqtt.connected() == 1) {
-                        u8g2.setCursor(41, 2);
+                        u8g2.setCursor(24, 2);
                         u8g2.setFont(u8g2_font_profont11_tf);
                         u8g2.print("MQTT");
                     } else {
-                        u8g2.setCursor(41, 2);
+                        u8g2.setCursor(24, 2);
                         u8g2.print("");
                     }
                 }

--- a/src/display.h
+++ b/src/display.h
@@ -181,11 +181,11 @@ void Displaymachinestate() {
 
             if (MQTT == 1) {
                 if (mqtt.connected() == 1) {
-                    u8g2.setCursor(77, 1);
+                    u8g2.setCursor(60, 1);
                     u8g2.setFont(u8g2_font_profont11_tf);
                     u8g2.print("MQTT");
                 } else {
-                    u8g2.setCursor(77, 2);
+                    u8g2.setCursor(60, 2);
                     u8g2.print("");
                 }
             }


### PR DESCRIPTION
After removing Blnyk, there is empty space in the status bar between Wifi signal bars and MQTT Icon.
Move MQTT Icon in all display versions closer to Wifi Signal Bars