### PR TITLE
Remove old TSIC Lib

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -6,7 +6,6 @@ extra_configs = platformio_extra.ini
 [env]
 lib_deps =
     lebuni/ZACwire for TSic @ 2.0.0
-    schm1tz1/TSIC @ 1.1.2
     milesburton/DallasTemperature @ 3.11.0
     paulstoffregen/OneWire @ 2.3.7
     olkal/HX711_ADC @ 1.2.12

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,7 +22,6 @@
 
 #include <WiFiManager.h>
 #include <U8g2lib.h>            // i2c display
-#include "TSIC.h"               // old library for TSIC temp sensor
 #include <ZACwire.h>            // new TSIC bus library
 #include "PID_v1.h"             // for PID calculation
 


### PR DESCRIPTION
old TSIC lib was only needed on esp8266, so removed