### PR TITLE
Fixed scale pin names

### DIFF
--- a/src/brewscaleini.h
+++ b/src/brewscaleini.h
@@ -6,6 +6,7 @@
  */
 
 #pragma once
+#include <pinmapping.h>
 
 // Analog Input
 #if PINBREWSWITCH == 0
@@ -54,5 +55,5 @@ unsigned long previousMillistempanalogreading;      // ms for analogreading
     bool scaleFailure = false;
     const unsigned long intervalWeight = 200;           // weight scale
     unsigned long previousMillisScale;                  // initialisation at the end of init()
-    HX711_ADC LoadCell(HXDATPIN, HXCLKPIN);
+    HX711_ADC LoadCell(PIN_HXDAT, PIN_HXCLK);
 #endif


### PR DESCRIPTION
Fixed scale pin references after naming convention changed alongside other ESP32 changes.