### PR TITLE
configurable Steamswitch

### DIFF
--- a/src/EmbeddedWebserver.h
+++ b/src/EmbeddedWebserver.h
@@ -327,8 +327,6 @@ void serverSetup() {
             writeSysParamsToMQTT();
 
         } else if (request->method() == 1) {  //WebRequestMethod enum -> HTTP_GET
-            //return all params as json
-            DynamicJsonDocument doc(JSON_ARRAY_SIZE(1) + JSON_OBJECT_SIZE(9+4) * EDITABLE_VARS_LEN);
 
             //get parameter id from frst parameter, e.g. /parameters?param=PID_ON
             int paramCount = request->params();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1912,8 +1912,7 @@ void setup() {
         pinMode(PIN_BREWSWITCH, INPUT_PULLDOWN);
     }
 
-    pinMode(PIN_STEAMSWITCH, INPUT_PULLDOWN);
-
+    // IF OLED Display is connected  
     #if OLED_DISPLAY != 0
         u8g2.setI2CAddress(oled_i2c * 2);
         u8g2.begin();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -838,14 +838,18 @@ float filterPressureValue(float input) {
  * @brief steamON & Quickmill
  */
 void checkSteamON() {
-    // check digital GIPO
-    if (digitalRead(PIN_STEAMSWITCH) == HIGH) {
-        steamON = 1;
-    }
+    
+    if (STEAMSWITCHTYPE > 0){
 
-    // if activated via web interface then steamFirstON == 1, prevent override
-    if (digitalRead(PIN_STEAMSWITCH) == LOW && steamFirstON == 0) {
-        steamON = 0;
+        // check digital GIPO
+        if (digitalRead(PIN_STEAMSWITCH) == HIGH) {
+            steamON = 1;
+        }
+
+        // if activated via web interface then steamFirstON == 1, prevent override
+        if (digitalRead(PIN_STEAMSWITCH) == LOW && steamFirstON == 0) {
+            steamON = 0;
+        }
     }
 
     // monitor QuickMill thermoblock steam-mode
@@ -1894,7 +1898,6 @@ void setup() {
     pinMode(PIN_VALVE, OUTPUT);
     pinMode(PIN_PUMP, OUTPUT);
     pinMode(PIN_HEATER, OUTPUT);
-    pinMode(PIN_STEAMSWITCH, INPUT);
     digitalWrite(PIN_VALVE, relayOFF);
     digitalWrite(PIN_PUMP, relayOFF);
     digitalWrite(PIN_HEATER, LOW);
@@ -1902,6 +1905,11 @@ void setup() {
     // IF POWERSWITCH is connected
     if (POWERSWITCHTYPE > 0) {
         pinMode(PIN_POWERSWITCH, INPUT);
+    }
+
+    // IF STEAMSWITCH is connected
+    if (STEAMSWITCHTYPE > 0) {
+        pinMode(PIN_STEAMSWITCH, INPUT);
     }
 
     // IF Voltage sensor selected

--- a/src/userConfig_sample.h
+++ b/src/userConfig_sample.h
@@ -57,6 +57,7 @@ enum MACHINE {
 #define BREWDETECTION 0            // 0 = off, 1 = Software (Onlypid 1), 2 = Hardware (Onlypid 0), 3 = Sensor/Hardware for Only PID
 #define BREWSWITCHTYPE 1           // 1 = normal Switch, 2 = Trigger Switch
 #define POWERSWITCHTYPE 0          // 0 = no switch connected, 1 = normal Switch, 2 = Trigger Switch
+#define STEAMSWITCHTYPE 0          // 0 = no switch connected, 1 = normal Switch, 2 = Trigger Switch
 #define TRIGGERTYPE HIGH           // LOW = low trigger, HIGH = high trigger relay for pump & valve
 #define VOLTAGESENSORTYPE HIGH     // BREWDETECTION 3 configuration
 #define PINMODEVOLTAGESENSOR INPUT // Mode INPUT_PULLUP, INPUT or INPUT_PULLDOWN_16 (Only Pin 16)


### PR DESCRIPTION
remove double pin definition for steam switch
steamswitchtyp configurable in unserconfig
only initiate and read pin_steamswitch when Steamswitchtype > 0 