### PR TITLE
Add a configurable standby mode that turns off the heater after a certain amount of time

### DIFF
--- a/data/js/app.js
+++ b/data/js/app.js
@@ -67,7 +67,8 @@ const vueApp = Vue.createApp({
             const sectionNames = {
                 0: 'PID Parameters',
                 1: 'Temperature and Preinfusion',
-                2: 'Brew Detection and Brew PID Parameters'
+                2: 'Brew Detection and Brew PID Parameters',
+                3: 'Power Settings'
             }
             return sectionNames[sectionId]
         }

--- a/src/EmbeddedWebserver.h
+++ b/src/EmbeddedWebserver.h
@@ -59,7 +59,7 @@ void serverSetup();
 void setEepromWriteFcn(int (*fcnPtr)(void));
 
 // editable vars are specified in main.cpp
-#define EDITABLE_VARS_LEN 27
+#define EDITABLE_VARS_LEN 29
 extern std::map<String, editable_t> editableVars;
 
 

--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -60,6 +60,8 @@ typedef struct __attribute__((packed)) {
     double weightSetpoint;
     double steamkp;
     double steamSetpoint;
+    uint8_t standbyModeOn;
+    double standbyModeTime;
 } sto_data_t;
 
 // set item defaults
@@ -107,7 +109,9 @@ static const sto_data_t itemDefaults PROGMEM = {
     "",                                       // STO_ITEM_WIFI_PASSWORD
     SCALE_WEIGHTSETPOINT,                     // STO_ITEM_WEIGHTSETPOINT
     STEAMKP,                                  // STO_ITEM_PID_KP_STEAM
-    STEAMSETPOINT                             // STO_ITEM_STEAM_SETPOINT
+    STEAMSETPOINT,                            // STO_ITEM_STEAM_SETPOINT
+    STANDBY_MODE_ON,                          // STO_ITEM_STANDBY_MODE_ON
+    STANDBY_MODE_TIME                         // STO_ITEM_STANDBY_MODE_TIME 
 };
 
 /**
@@ -245,19 +249,29 @@ static inline int32_t getItemAddr(sto_item_id_t itemId, uint16_t* maxItemSize = 
             size = STRUCT_MEMBER_SIZE(sto_data_t, pidOn);
             break;
 
-         case STO_ITEM_PID_KP_STEAM:
+        case STO_ITEM_PID_KP_STEAM:
             addr = offsetof(sto_data_t, steamkp);
             size = STRUCT_MEMBER_SIZE(sto_data_t, steamkp);
             break;
 
-         case STO_ITEM_WEIGHTSETPOINT:
-            addr = offsetof(sto_data_t,weightSetpoint );
+        case STO_ITEM_WEIGHTSETPOINT:
+            addr = offsetof(sto_data_t, weightSetpoint );
             size = STRUCT_MEMBER_SIZE(sto_data_t,weightSetpoint);
             break;
 
         case STO_ITEM_STEAM_SETPOINT:
-            addr = offsetof(sto_data_t,steamSetpoint );
+            addr = offsetof(sto_data_t, steamSetpoint);
             size = STRUCT_MEMBER_SIZE(sto_data_t,steamSetpoint);
+            break;
+
+        case STO_ITEM_STANDBY_MODE_ON:
+            addr = offsetof(sto_data_t, standbyModeOn);
+            size = STRUCT_MEMBER_SIZE(sto_data_t,standbyModeOn);
+            break;
+
+        case STO_ITEM_STANDBY_MODE_TIME:
+            addr = offsetof(sto_data_t, standbyModeTime);
+            size = STRUCT_MEMBER_SIZE(sto_data_t,standbyModeTime);
             break;
 
         default:

--- a/src/Storage.h
+++ b/src/Storage.h
@@ -40,8 +40,10 @@ typedef enum
   STO_ITEM_WIFI_SSID,               // Wifi SSID
   STO_ITEM_WIFI_PASSWORD,           // Wifi password
   STO_ITEM_WEIGHTSETPOINT,          // Brew weight setpoint
-  STO_ITEM_RESERVED_28,             // reserved
-  STO_ITEM_RESERVED_29,             // reserved
+  STO_ITEM_STANDBY_MODE_ON,         // Enable tandby mode
+  STO_ITEM_STANDBY_MODE_TIME,       // Time until heater is turned off
+  STO_ITEM_RESERVED_30,             // reserved
+  STO_ITEM_RESERVED_21,             // reserved
 
   /* WHEN ADDING NEW ITEMS, THE FOLLOWING HAS TO BE UPDATED:
    * - storage structure:  sto_data_t

--- a/src/defaults.h
+++ b/src/defaults.h
@@ -36,11 +36,13 @@ int writeSysParamsToStorage(void);
 #define BREW_TIME 25               // brew time in seconds (only used if pump is being controlled)
 #define BREW_SW_TIME 25            // keep brew PID params for this many seconds after detection (only for software BD)
 #define BREW_PID_DELAY 10          // delay until enabling PID controller during brew (no heating during this time)
-#define BD_SENSITIVITY 120        // brew detection sensitivity, be careful: if too low, then there is the risk of wrong brew detection and rising temperature
+#define BD_SENSITIVITY 120         // brew detection sensitivity, be careful: if too low, then there is the risk of wrong brew detection and rising temperature
 #define PRE_INFUSION_TIME 2        // pre-infusion time in seconds
 #define PRE_INFUSION_PAUSE_TIME 5  // pre-infusion pause time in seconds
 #define SCALE_WEIGHTSETPOINT 30    // Target weight in grams
 #define WIFI_CREDENTIALS_SAVED 0   // Flag if wifi setup is done. 0: not set up, 1: credentials set up via wifi manager
+#define STANDBY_MODE_ON 0          // Standby mode off by default
+#define STANDBY_MODE_TIME 30       // Time in minutes until the heater is turned off   
 
 // Backflush values
 #define FILLTIME 3000              // time in ms the pump is running
@@ -91,4 +93,6 @@ int writeSysParamsToStorage(void);
 #define WEIGHTSETPOINT_MAX 500
 #define PID_KP_STEAM_MIN 0
 #define PID_KP_STEAM_MAX 500
+#define STANDBY_MODE_TIME_MIN 30
+#define STANDBY_MODE_TIME_MAX 120
 

--- a/src/display.h
+++ b/src/display.h
@@ -225,6 +225,15 @@ void Displaymachinestate() {
         u8g2.sendBuffer();
     }
 
+    if (OFFLINEGLOGO == 1 && machineState == kStandby) {
+        u8g2.clearBuffer();
+        u8g2.drawXBMP(38, 0, OFFLogo_width, OFFLogo_height, OFFLogo);
+        u8g2.setCursor(36, 55);
+        u8g2.setFont(u8g2_font_profont10_tf);
+        u8g2.print("Standby mode");
+        u8g2.sendBuffer();
+    }
+
     // Steam
     if (machineState == kSteam) {
         u8g2.clearBuffer();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -76,6 +76,7 @@ enum MachineState {
     kBackflush = 50,
     kEmergencyStop = 80,
     kPidOffline = 90,
+    kStandby = 95,
     kSensorError = 100,
     kEepromError = 110,
 };
@@ -163,7 +164,8 @@ char *number2string(int in);
 char *number2string(unsigned int in);
 float filterPressureValue(float input);
 void writeSysParamsToMQTT(void);
-
+void updateStandbyTimer(void);
+void resetStandbyTimer(void);
 
 // system parameters
 uint8_t pidON = 0;                 // 1 = control loop in closed loop
@@ -201,6 +203,11 @@ double brewtimesoftware = BREW_SW_TIME;  // use userConfig time until disabling 
 double brewSensitivity = BD_SENSITIVITY;  // use userConfig brew detection sensitivity
 double brewPIDDelay = BREW_PID_DELAY;      // use userConfig brew detection PID delay
 
+uint8_t standbyModeOn = 0;
+double standbyModeTime = STANDBY_MODE_TIME;
+
+#include "standby.h"
+
 // system parameter EEPROM storage wrappers (current value as pointer to variable, minimum, maximum, optional storage ID)
 SysPara<uint8_t> sysParaPidOn(&pidON, 0, 1, STO_ITEM_PID_ON);
 SysPara<uint8_t> sysParaUsePonM(&usePonM, 0, 1, STO_ITEM_PID_START_PONM);
@@ -226,6 +233,8 @@ SysPara<double> sysParaPreInfPause(&preinfusionpause, PRE_INFUSION_PAUSE_MIN, PR
 SysPara<double> sysParaPidKpSteam(&steamKp, PID_KP_STEAM_MIN, PID_KP_STEAM_MAX, STO_ITEM_PID_KP_STEAM);
 SysPara<double> sysParaSteamSetpoint(&steamSetpoint, STEAM_SETPOINT_MIN, STEAM_SETPOINT_MAX, STO_ITEM_STEAM_SETPOINT);
 SysPara<double> sysParaWeightSetpoint(&weightSetpoint, WEIGHTSETPOINT_MIN, WEIGHTSETPOINT_MAX, STO_ITEM_WEIGHTSETPOINT);
+SysPara<uint8_t> sysParaStandbyModeOn(&standbyModeOn, 0, 1, STO_ITEM_STANDBY_MODE_ON);
+SysPara<double> sysParaStandbyModeTime(&standbyModeTime, STANDBY_MODE_TIME_MIN, STANDBY_MODE_TIME_MAX, STO_ITEM_STANDBY_MODE_TIME);
 
 // Other variables
 int relayON, relayOFF;           // used for relay trigger type. Do not change!
@@ -310,6 +319,7 @@ enum SectionNames {
     sPIDSection,
     sTempSection,
     sBDSection,
+    sPowerSection,
     sOtherSection
 };
 
@@ -971,23 +981,41 @@ void handleMachineState() {
                 (ONLYPID == 0 && brewcounter > kBrewIdle && brewcounter <= kBrewFinished))
             {
                 machineState = kBrew;
+
+                if (standbyModeOn) {
+                    resetStandbyTimer();
+                } 
             }
 
             if (steamON == 1) {
                 machineState = kSteam;
+
+                if (standbyModeOn) {
+                    resetStandbyTimer();
+                } 
             }
 
             if (backflushON || backflushState > 10) {
                 machineState = kBackflush;
+
+                if (standbyModeOn) {
+                    resetStandbyTimer();
+                } 
             }
 
-            if (pidON == 0) {
+            if (standbyModeOn && standbyModeRemainingTimeMillis == 0) {
+                machineState = kStandby;
+                pidON = 0;
+            }
+
+            if (pidON == 0 && machineState != kStandby) {
                 machineState = kPidOffline;
             }
 
             if (sensorError) {
                 machineState = kSensorError;
             }
+
             break;
 
         // Setpoint is below current temperature
@@ -1002,23 +1030,41 @@ void handleMachineState() {
                 (ONLYPID == 0 && brewcounter > kBrewIdle && brewcounter <= kBrewFinished))
             {
                 machineState = kBrew;
+
+                if (standbyModeOn) {
+                    resetStandbyTimer();
+                } 
             }
 
             if (backflushON || backflushState > 10) {
                 machineState = kBackflush;
+
+                if (standbyModeOn) {
+                    resetStandbyTimer();
+                } 
             }
 
             if (steamON == 1) {
                 machineState = kSteam;
+
+                if (standbyModeOn) {
+                    resetStandbyTimer();
+                } 
             }
 
-            if (pidON == 0) {
+            if (standbyModeOn && standbyModeRemainingTimeMillis == 0) {
+                machineState = kStandby;
+                pidON = 0;
+            }
+
+            if (pidON == 0 && machineState != kStandby) {
                 machineState = kPidOffline;
             }
 
             if (sensorError) {
                 machineState = kSensorError;
             }
+
             break;
 
         case kPidNormal:
@@ -1032,17 +1078,30 @@ void handleMachineState() {
 
             if (steamON == 1) {
                 machineState = kSteam;
+
+                if (standbyModeOn) {
+                    resetStandbyTimer();
+                } 
             }
 
             if (backflushON || backflushState > 10) {
                 machineState = kBackflush;
+
+                if (standbyModeOn) {
+                    resetStandbyTimer();
+                } 
             }
 
             if (emergencyStop) {
                 machineState = kEmergencyStop;
             }
+             
+            if (standbyModeOn && standbyModeRemainingTimeMillis == 0) {
+                machineState = kStandby;
+                pidON = 0;
+            }
 
-            if (pidON == 0) {
+            if (pidON == 0 && machineState != kStandby) {
                 machineState = kPidOffline;
             }
 
@@ -1262,6 +1321,27 @@ void handleMachineState() {
                 machineState = kSensorError;
             }
             break;
+        
+        case kStandby:
+            brewDetection();
+            
+            if (pidON || steamON || isBrewDetected) {
+                pidON = 1;
+                resetStandbyTimer();
+
+                if (steamON) {
+                    machineState = kSteam;
+                } else if (isBrewDetected) {
+                    machineState = kBrew;
+                } else {
+                    machineState = kPidNormal;
+                }
+            }
+             
+            if (sensorError) {
+                machineState = kSensorError;
+            }
+            break;
 
         case kSensorError:
             machineState = kSensorError;
@@ -1309,6 +1389,8 @@ char const* machinestateEnumToString(MachineState machineState) {
             return "Emergency Stop";
         case kPidOffline:
             return "PID Offline";
+        case kStandby:
+            return "Standby Mode";
         case kSensorError:
             return "Sensor Error";
         case kEepromError:
@@ -1810,13 +1892,40 @@ void setup() {
         .ptr = (void *)&backflushON
     };
 
+    editableVars["STANDBY_MODE_ON"] = {
+        .displayName = F("Enable Standby Timer"),
+        .hasHelpText = true,
+        .helpText = F("Turn heater off after standby time has elapsed."),
+        .type = kUInt8,
+        .section = sPowerSection,
+        .position = 27,
+        .show = [] { return true; },
+        .minValue = 0,
+        .maxValue = 1,
+        .ptr = (void *)&standbyModeOn
+    };
+
+    editableVars["STANDBY_MODE_TIMER"] = {
+        .displayName = F("Standby Time"),
+        .hasHelpText = true,
+        .helpText = F(
+            "Time in minutes until the heater is turned off. Timer is reset by brew detection."),
+        .type = kDouble,
+        .section = sPowerSection,
+        .position = 28,
+        .show = [] { return true; },
+        .minValue = STANDBY_MODE_TIME_MIN,
+        .maxValue = STANDBY_MODE_TIME_MAX,
+        .ptr = (void *)&standbyModeTime
+    };
+
     editableVars["VERSION"] = {
         .displayName = F("Version"),
         .hasHelpText = false,
         .helpText = "",
         .type = kCString,
         .section = sOtherSection,
-        .position = 27,
+        .position = 29,
         .show = [] { return false; },
         .minValue = 0,
         .maxValue = 1,
@@ -1840,6 +1949,7 @@ void setup() {
     mqttVars["aggTv"] = []{ return &editableVars.at("PID_TV"); };
     mqttVars["aggIMax"] = []{ return &editableVars.at("PID_I_MAX"); };
     mqttVars["steamKp"] = []{ return &editableVars.at("STEAM_KP"); };
+    mqttVars["standbyModeOn"] = []{ return &editableVars.at("STANDBY_MODE_ON"); };
 
     if (ONLYPID == 0) {
         mqttVars["brewtime"] = []{ return &editableVars.at("BREW_TIME"); };
@@ -1866,6 +1976,7 @@ void setup() {
     // Values reported to MQTT
     mqttSensors["temperature"] = []{ return temperature; };
     mqttSensors["heaterPower"] = []{ return pidOutput; };
+    mqttSensors["standbyModeTimeRemaining"] = []{ return standbyModeRemainingTimeMillis / 1000; };
     mqttSensors["currentKp"] = []{ return bPID.GetKp(); };
     mqttSensors["currentKi"] = []{ return bPID.GetKi(); };
     mqttSensors["currentKd"] = []{ return bPID.GetKd(); };
@@ -2101,11 +2212,15 @@ void looppid() {
         checkPressure();
     #endif
 
-    brew();                  // start brewing if button pressed
-    checkSteamON();          // check for steam
+    brew();
+    checkSteamON();
     setEmergencyStopTemp();
     checkpowerswitch();
-    handleMachineState();      // update machineState
+    handleMachineState();
+
+    if (standbyModeOn && machineState != kStandby) {
+        updateStandbyTimer();
+    }
 
     if (INFLUXDB == 1  && offlineMode == 0 ) {
         sendInflux();
@@ -2130,7 +2245,7 @@ void looppid() {
     }
 #endif
 
-    if (machineState == kPidOffline || machineState == kSensorError || machineState == kEmergencyStop || machineState == kEepromError || brewPIDdisabled) {
+    if (machineState == kPidOffline || machineState == kSensorError || machineState == kEmergencyStop || machineState == kEepromError || machineState == kStandby || brewPIDdisabled) {
         if (pidMode == 1) {
             // Force PID shutdown
             pidMode = 0;
@@ -2334,6 +2449,8 @@ int readSysParamsFromStorage(void) {
     if (sysParaSteamSetpoint.getStorage() != 0) return -1;
     if (sysParaWeightSetpoint.getStorage() != 0) return -1;
     if (sysParaWifiCredentialsSaved.getStorage() != 0) return -1;
+    if (sysParaStandbyModeOn.getStorage() != 0) return -1;
+    if (sysParaStandbyModeTime.getStorage() != 0) return -1;
 
     return 0;
 }
@@ -2368,6 +2485,8 @@ int writeSysParamsToStorage(void) {
     if (sysParaSteamSetpoint.setStorage() != 0) return -1;
     if (sysParaWeightSetpoint.setStorage() != 0) return -1;
     if (sysParaWifiCredentialsSaved.setStorage() != 0) return -1;
+    if (sysParaStandbyModeOn.setStorage() != 0) return -1;
+    if (sysParaStandbyModeTime.setStorage() != 0) return -1;
 
     return storageCommit();
 }

--- a/src/standby.h
+++ b/src/standby.h
@@ -1,0 +1,42 @@
+/**
+ * @file standby.h
+ * 
+ * @brief Standby mode
+*/
+
+#pragma once
+
+unsigned long standbyModeStartTimeMillis = millis();
+unsigned long standbyModeRemainingTimeMillis = standbyModeTime * 60 * 1000;
+unsigned long lastStandbyTimeMillis = standbyModeStartTimeMillis;
+
+/**
+ * @brief Decrements the remaining standby time every second, counting down from the configured duration 
+ */
+void updateStandbyTimer(void) {
+    unsigned long currentTime = millis();
+
+    if ((standbyModeRemainingTimeMillis != 0) && ((currentTime % 1000) == 0) && (currentTime != lastStandbyTimeMillis)) {
+        unsigned long standbyModeTimeMillis = standbyModeTime * 60 * 1000;
+        long elapsedTime = currentTime - standbyModeStartTimeMillis;
+        lastStandbyTimeMillis = currentTime;
+
+        if (standbyModeTimeMillis > elapsedTime) {
+            standbyModeRemainingTimeMillis = standbyModeTimeMillis - elapsedTime;
+
+            if ((currentTime % 60000) == 0) {
+                debugPrintf("Standby time remaining: %i minutes\n", standbyModeRemainingTimeMillis / 60000);
+            }
+        }
+        else {
+            standbyModeRemainingTimeMillis = 0;
+        }
+    }
+}
+
+void resetStandbyTimer(void) {
+    standbyModeRemainingTimeMillis = standbyModeTime * 60 * 10000;
+    standbyModeStartTimeMillis = millis();
+
+    debugPrintf("Resetting standby timer to %i minutes\n",  (int)standbyModeTime);
+}


### PR DESCRIPTION
* Add a new power section in the web interface
* Switch standby mode on or off, set the duration until the heater is turned off 
* Ways to exit the standby mode:
   * Brew detection
   * Toggle pid controller/steam mode from web interface
   * Set pidON/steamON to 1 via MQTT
* Timer counts down from the configured duration and is reset by state transitions to kBrew, kSteam and kBackflush