### PR TITLE
pinmapping based on MCU type

### DIFF
--- a/src/ISR.cpp
+++ b/src/ISR.cpp
@@ -1,6 +1,6 @@
 #include <Arduino.h>
 #include "ISR.h"
-#include "userConfig.h"
+#include "hardware.h"
 
 unsigned int isrCounter = 0;  // counter for ISR
 unsigned long windowStartTime;

--- a/src/esp32devkitcv4.h
+++ b/src/esp32devkitcv4.h
@@ -1,0 +1,42 @@
+/*
+ * ESP32 Pin Mapping on "clevercoffee_ESP32_minimal" pcb rev 1.2 or higher and "clevercoffee_ESP32" pcb rev 1.2 or higher
+ */
+
+/**
+ * Input Pins
+ */
+
+// Switches/Buttons
+#define PINPOWERSWITCH 39
+#define PINBREWSWITCH 34
+#define PINSTEAMSWITCH 35
+
+
+// Sensors
+#define PINTEMPSENSOR 16
+#define PINPRESSURESENSOR 23
+#define PINVOLTAGESENSOR 34    // Input pin for voltage sensor (optocoupler to detect brew switch)
+#define HXDATPIN 32            // Brew scale data pin
+#define HXCLKPIN 33            // Brew scale clock pin
+
+
+/**
+ * Output pins
+ */
+
+// Relays
+#define PINVALVE 17
+#define PINPUMP 27
+#define PINHEATER 2
+
+// LEDs
+#define LEDPIN 26
+
+// Periphery
+#define PINETRIGGER 25          // PIN for E-Trigger relay
+
+/**
+ * Bidirectional Pins
+ */
+#define OLED_SCL 22
+#define OLED_SDA 21

--- a/src/esp32devkitcv4.h
+++ b/src/esp32devkitcv4.h
@@ -15,7 +15,6 @@
 // Sensors
 #define PINTEMPSENSOR 16
 #define PINPRESSURESENSOR 23
-#define PINVOLTAGESENSOR 34    // Input pin for voltage sensor (optocoupler to detect brew switch)
 #define HXDATPIN 32            // Brew scale data pin
 #define HXCLKPIN 33            // Brew scale clock pin
 

--- a/src/esp8266nodemcuv2.h
+++ b/src/esp8266nodemcuv2.h
@@ -9,7 +9,6 @@
 #define PINVALVE 12
 #define PINPUMP 13
 #define PINHEATER 14
-#define PINVOLTAGESENSOR 15        // Input pin for voltage sensor (optocoupler to detect brew switch)
 #define PINETRIGGER 16             // PIN for E-Trigger relay
 #define PINBREWSWITCH 15           // 0: A0 (ESP8266) ; >0 : DIGITAL PIN ESP8266: ONLY USE PIN15 AND PIN16!
 #define PINSTEAMSWITCH 17

--- a/src/esp8266nodemcuv2.h
+++ b/src/esp8266nodemcuv2.h
@@ -1,0 +1,30 @@
+/*
+ * ESP8266 Pin Mapping on "esp8266 pcb rev 1.2"
+ */
+
+// Pin Layout
+#define PINTEMPSENSOR 2            
+#define PINPRESSURESENSOR 0       // Pressure sensor 0: A0 (ESP8266), >0 ONLY ESP32
+#define PINPOWERSWITCH 99          // Input pin for powerswitch (use a pin which is LOW on startup or use an pull down resistor)
+#define PINVALVE 12
+#define PINPUMP 13
+#define PINHEATER 14
+#define PINVOLTAGESENSOR 15        // Input pin for voltage sensor (optocoupler to detect brew switch)
+#define PINETRIGGER 16             // PIN for E-Trigger relay
+#define PINBREWSWITCH 15           // 0: A0 (ESP8266) ; >0 : DIGITAL PIN ESP8266: ONLY USE PIN15 AND PIN16!
+#define PINSTEAMSWITCH 17
+#define LEDPIN 18                  // LED PIN ON near setpoint
+#define OLED_SCL 5                 // Output pin for display clock pin
+#define OLED_SDA 4                 // Output pin for display data pin
+#define HXDATPIN 99                // weight scale data pin
+#define HXCLKPIN 99                // weight scale clock pin
+
+// Check BrewSwitch
+#if (defined(ESP8266) && ((PINBREWSWITCH != 15 && PINBREWSWITCH != 0 && PINBREWSWITCH != 16 )))
+  #error("WRONG Brewswitch PIN for ESP8266, Only PIN 0, PIN 15 and PIN 16");
+#endif
+
+// defined compiler errors
+#if (PRESSURESENSOR == 1) && (PINPRESSURESENSOR == 0) && (PINBREWSWITCH == 0)
+  #error Change PINBREWSWITCH or PRESSURESENSOR!
+#endif

--- a/src/esp8266nodemcuv2.h
+++ b/src/esp8266nodemcuv2.h
@@ -4,15 +4,15 @@
 
 // Pin Layout
 #define PINTEMPSENSOR 2            
-#define PINPRESSURESENSOR 0       // Pressure sensor 0: A0 (ESP8266), >0 ONLY ESP32
+#define PINPRESSURESENSOR 0        // Pressure sensor 0: A0 (ESP8266), >0 ONLY ESP32
 #define PINPOWERSWITCH 99          // Input pin for powerswitch (use a pin which is LOW on startup or use an pull down resistor)
 #define PINVALVE 12
 #define PINPUMP 13
 #define PINHEATER 14
 #define PINETRIGGER 16             // PIN for E-Trigger relay
-#define PINBREWSWITCH 15           // 0: A0 (ESP8266) ; >0 : DIGITAL PIN ESP8266: ONLY USE PIN15 AND PIN16!
-#define PINSTEAMSWITCH 17
-#define LEDPIN 18                  // LED PIN ON near setpoint
+#define PINBREWSWITCH 15           // For switch, trigger or optocoupler 
+#define PINSTEAMSWITCH 99
+#define LEDPIN 99                  // LED PIN ON near setpoint
 #define OLED_SCL 5                 // Output pin for display clock pin
 #define OLED_SDA 4                 // Output pin for display data pin
 #define HXDATPIN 99                // weight scale data pin

--- a/src/hardware.h
+++ b/src/hardware.h
@@ -1,0 +1,11 @@
+/*
+ * Standard pin mappings based on MCU type 
+ */
+
+#if defined(ESP32)
+    #include "esp32devkitcv4.h"
+#elif defined(ESP8266)
+    #include "esp8266nodemcuv2.h"
+#else
+    #error("MCU not supported");
+#endif

--- a/src/rancilio-pid.cpp
+++ b/src/rancilio-pid.cpp
@@ -863,13 +863,13 @@ void brewDetection() {
         }
     } else if (brewDetectionMode == 3) {
         // timeBrewed counter
-        if ((digitalRead(PINVOLTAGESENSOR) == VoltageSensorON) && brewDetected == 1) {
+        if ((digitalRead(PINBREWSWITCH) == VoltageSensorON) && brewDetected == 1) {
             timeBrewed = millis() - startingTime;
             lastbrewTime = timeBrewed;
         }
 
         // OFF: reset brew
-        if ((digitalRead(PINVOLTAGESENSOR) == VoltageSensorOFF) && (brewDetected == 1 || coolingFlushDetectedQM == true)) {
+        if ((digitalRead(PINBREWSWITCH) == VoltageSensorOFF) && (brewDetected == 1 || coolingFlushDetectedQM == true)) {
             isBrewDetected = 0;  // rearm brewDetection
             brewDetected = 0;
             timePVStoON = timeBrewed;  // for QuickMill
@@ -899,7 +899,7 @@ void brewDetection() {
         switch (machine) {
             case QuickMill:
                 if (!coolingFlushDetectedQM) {
-                    int pvs = digitalRead(PINVOLTAGESENSOR);
+                    int pvs = digitalRead(PINBREWSWITCH);
                     if (pvs == VoltageSensorON && brewDetected == 0 &&
                         brewSteamDetectedQM == 0 && !steamQM_active) {
                         timeBrewDetection = millis();
@@ -942,7 +942,7 @@ void brewDetection() {
             // no Quickmill:
             default:
                 previousMillisVoltagesensorreading = millis();
-                if (digitalRead(PINVOLTAGESENSOR) == VoltageSensorON && brewDetected == 0) {
+                if (digitalRead(PINBREWSWITCH) == VoltageSensorON && brewDetected == 0) {
                     debugPrintln("HW Brew - Voltage Sensor - Start");
                     timeBrewDetection = millis();
                     startingTime = millis();
@@ -1118,18 +1118,18 @@ void setEmergencyStopTemp() {
 
 void initSteamQM() {
     // Initialize monitoring for steam switch off for QuickMill thermoblock
-    lastTimePVSwasON = millis();  // time when pinvoltagesensor changes from ON to OFF
+    lastTimePVSwasON = millis();  // time when PINBREWSWITCH changes from ON to OFF
     steamQM_active = true;
     timePVStoON = 0;
     steamON = 1;
 }
 
 boolean checkSteamOffQM() {
-    /* Monitor pinvoltagesensor during active steam mode of QuickMill
+    /* Monitor PINBREWSWITCH during active steam mode of QuickMill
      * thermoblock. Once the pinvolagesenor remains OFF for longer than a
      * pump-pulse time peride the switch is turned off and steam mode finished.
      */
-    if (digitalRead(PINVOLTAGESENSOR) == VoltageSensorON) {
+    if (digitalRead(PINBREWSWITCH) == VoltageSensorON) {
         lastTimePVSwasON = millis();
     }
 
@@ -1790,7 +1790,7 @@ void setup() {
 
     // IF Voltage sensor selected
     if (BREWDETECTION == 3) {
-        pinMode(PINVOLTAGESENSOR, PINMODEVOLTAGESENSOR);
+        pinMode(PINBREWSWITCH, PINMODEVOLTAGESENSOR);
     }
 
     // IF PINBREWSWITCH & Steam selected

--- a/src/rancilio-pid.cpp
+++ b/src/rancilio-pid.cpp
@@ -3,13 +3,13 @@
  *
  * @brief Main sketch
  *
- * @version 3.1.1 Master
+ * @version 3.2.0 Master
  */
 
 // Firmware version
 #define FW_VERSION    3
-#define FW_SUBVERSION 1
-#define FW_HOTFIX     2
+#define FW_SUBVERSION 2
+#define FW_HOTFIX     0
 #define FW_BRANCH     "ESP8222-MASTER"
 
 // User Config

--- a/src/rancilio-pid.cpp
+++ b/src/rancilio-pid.cpp
@@ -32,6 +32,7 @@
 #include "PID_v1.h"             // for PID calculation
 
 // Includes
+#include "hardware.h"           // pinmapping esp8266 or esp32
 #include "icon.h"               // user icons for display
 #include "languages.h"          // for language translation
 #include "Storage.h"

--- a/src/userConfig_sample.h
+++ b/src/userConfig_sample.h
@@ -33,6 +33,8 @@ enum MACHINE {
 #define OLED_I2C 0x3C              // I2C address for OLED, 0x3C by default
 #define DISPLAYTEMPLATE 3          // 1 = Standard display template, 2 = Minimal template, 3 = only temperature, 4 = scale template, 20 = vertical display (see git Handbook for further information)
 #define DISPLAYROTATE U8G2_R0      // rotate display clockwise: U8G2_R0 = no rotation; U8G2_R1 = 90°; U8G2_R2 = 180°; U8G2_R3 = 270°
+#define SCREEN_WIDTH 128           // OLED display width, in pixels
+#define SCREEN_HEIGHT 64           // OLED display height, in pixels
 #define SHOTTIMER 1                // 0 = deactivated, 1 = activated 2 = with scale
 #define HEATINGLOGO 0              // 0 = deactivated, 1 = Rancilio, 2 = Gaggia
 #define OFFLINEGLOGO 1             // 0 = deactivated, 1 = activated
@@ -113,41 +115,11 @@ enum MACHINE {
 // PID Parameters (not yet in Web interface)
 #define EMA_FACTOR 0.6             // Smoothing of input that is used for Tv (derivative component of PID). Smaller means less smoothing but also less delay, 0 means no filtering
 #define BREWPID_DELAY 10           // delay until enabling PID controller during brew (no heating during this time)
+#define TEMPSENSOR 2               // Temp sensor type: 1 = DS18B20, 2 = TSIC306
 
 // Backflush values
 #define FILLTIME 3000              // time in ms the pump is running
 #define FLUSHTIME 6000             // time in ms the 3-way valve is open -> backflush
 #define MAXFLUSHCYCLES 5           // number of cycles the backflush should run, 0 = disabled
-
-#define TEMPSENSOR 2               // Temp sensor type: 1 = DS18B20, 2 = TSIC306
-
-// Pin Layout
-#define PINTEMPSENSOR 2            
-#define PINPRESSURESENSOR 99       // Pressure sensor 0: A0 (ESP8266), >0 ONLY ESP32
-#define PINPOWERSWITCH 99          // Input pin for powerswitch (use a pin which is LOW on startup or use an pull down resistor)
-#define PINVALVE 12
-#define PINPUMP 13
-#define PINHEATER 14
-#define PINVOLTAGESENSOR 15        // Input pin for voltage sensor (optocoupler to detect brew switch)
-#define PINETRIGGER 16             // PIN for E-Trigger relay
-#define PINBREWSWITCH 0            // 0: A0 (ESP8266) ; >0 : DIGITAL PIN, ESP32 OR ESP8266: ONLY USE PIN15 AND PIN16!
-#define PINSTEAMSWITCH 17
-#define LEDPIN    18               // LED PIN ON near setpoint
-#define OLED_SCL 5                 // Output pin for display clock pin
-#define OLED_SDA 4                 // Output pin for display data pin
-#define HXDATPIN 99                // weight scale data pin
-#define HXCLKPIN 99                // weight scale clock pin
-#define SCREEN_WIDTH 128           // OLED display width, in pixels
-#define SCREEN_HEIGHT 64           // OLED display height, in pixels
-
-// Check BrewSwitch
-#if (defined(ESP8266) && ((PINBREWSWITCH != 15 && PINBREWSWITCH != 0 && PINBREWSWITCH != 16 )))
-  #error("WRONG Brewswitch PIN for ESP8266, Only PIN 15 and PIN 16");
-#endif
-
-// defined compiler errors
-#if (PRESSURESENSOR == 1) && (PINPRESSURESENSOR == 0) && (PINBREWSWITCH == 0)
-  #error Change PINBREWSWITCH or PRESSURESENSOR!
-#endif
 
 #endif

--- a/src/userConfig_sample.h
+++ b/src/userConfig_sample.h
@@ -1,7 +1,7 @@
 /**
  * @file    userConfig_sample.h
  * @brief   Values must be configured by the user
- * @version 3.1.1 Master
+ * @version 3.2.0 Master
  *
  */
 #ifndef _userConfig_H
@@ -9,8 +9,8 @@
 
 // firmware version (must match with definitions in the main source file)
 #define USR_FW_VERSION    3
-#define USR_FW_SUBVERSION 1
-#define USR_FW_HOTFIX     2
+#define USR_FW_SUBVERSION 2
+#define USR_FW_HOTFIX     0
 #define USR_FW_BRANCH     "ESP8222-MASTER"
 
 // List of supported machines


### PR DESCRIPTION
moved pinmapping out of userconfig, pinmapping based on MCU TYPE automatically
for esp8266 board manual changes based on feature set are still necessary, has to be done in "esp8266nodemcuv2.h"
change standard PINBREWSWITCH for esp8266, because PIN A0 mostly causes problems, PIN 15 is the better choise