### PR TITLE
Fix pinMode of PINBREWSWITCH for pid only hardware brew detection

### DIFF
--- a/src/rancilio-pid.cpp
+++ b/src/rancilio-pid.cpp
@@ -1795,7 +1795,7 @@ void setup() {
     }
 
     // IF PINBREWSWITCH & Steam selected
-    if (PINBREWSWITCH > 0) {
+    if (PINBREWSWITCH > 0 && BREWDETECTION != 3) {
         #if (defined(ESP8266) && PINBREWSWITCH == 16)
             pinMode(PINBREWSWITCH, INPUT_PULLDOWN_16);
         #endif


### PR DESCRIPTION
If BREWDETECTION is set to 3 PID only hardware brew detection with an optocoupler the pinMode of PINBREWSWITCH is not set correctly.  In this case the pinMode should be what is set for PINMODEVOLTAGESENSOR. But after setting it to the correct value it is directly overwritten in the next if block.