### PR TITLE
Increase maxChangeRate for TSic 306 sensor

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -586,7 +586,7 @@ void refreshTemp() {
             previousMillistemp = currentMillistemp;
 
             #if TEMPSENSOR == 2
-                temperature = Sensor2.getTemp();
+                temperature = Sensor2.getTemp(15);
             #endif
 
             if (machineState != kSteam) {
@@ -2104,7 +2104,7 @@ void setup() {
 
     // TSic 306 temp sensor
     #if TEMPSENSOR == 2
-        temperature = Sensor2.getTemp();
+        temperature = Sensor2.getTemp(15);
     #endif
 
     temperature -= brewTempOffset;


### PR DESCRIPTION
I regularly had the issue, that my machine would run in an emergency stop during a coldstart. It appears, that my machine exceeds the default maxChangeRate of 10°C/s of the ZACwire library. This PR  increases the expected maximum temperature change rate before ZACwire library will throw an error (see https://github.com/lebuni/ZACwire-Library#adjustment-for-fast-systems for reference)