### PR TITLE
use debugPrintf instead of Serial.print* and fix format string

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2131,9 +2131,9 @@ void setup() {
 
     enableTimer1();
 
-    Serial.println("Filesystem overview:");
-    Serial.printf("- Bytes total: ld\n", LittleFS.totalBytes());
-    Serial.printf("- Bytes used: %ld\n\n", LittleFS.usedBytes());
+    double fsUsage = ((double)LittleFS.usedBytes() / LittleFS.totalBytes()) * 100;
+    debugPrintf("LittleFS: %d%% (used %ld bytes from %ld bytes)\n",
+        (int)ceil(fsUsage), LittleFS.usedBytes(), LittleFS.totalBytes());
 }
 
 


### PR DESCRIPTION
Not sure why LittleFS usage reporting did not use the existing debugPrintf function. Also, the format string for usage was not correct and not value was logged. 

So, this fix uses debugPrint, fixes the format string, calculates the percentage for the usage and prints one line.