### PR TITLE
Fix for MQTT Reconnect, bumb sw number

### DIFF
--- a/src/rancilio-pid.cpp
+++ b/src/rancilio-pid.cpp
@@ -3,13 +3,13 @@
  *
  * @brief Main sketch
  *
- * @version 3.2.0 Master
+ * @version 3.3.0 Master
  */
 
 // Firmware version
 #define FW_VERSION    3
-#define FW_SUBVERSION 2
-#define FW_HOTFIX     1
+#define FW_SUBVERSION 3
+#define FW_HOTFIX     0
 
 #define FW_BRANCH     "ESP8222-MASTER"
 
@@ -791,6 +791,7 @@ void checkMQTT() {
             debugPrintf("Attempting MQTT reconnection: %i\n", MQTTReCnctCount);
 
             if (mqtt.connect(hostname, mqtt_username, mqtt_password, topic_will, 0, 0, "offline") == true) {
+                MQTTReCnctCount = 0;
                 mqtt.subscribe(topic_set);
                 debugPrintln("Subscribe to MQTT Topics");
             }   // Try to reconnect to the server; connect() is a blocking

--- a/src/userConfig_sample.h
+++ b/src/userConfig_sample.h
@@ -1,7 +1,7 @@
 /**
  * @file    userConfig_sample.h
  * @brief   Values must be configured by the user
- * @version 3.2.0 Master
+ * @version 3.3.0 Master
  *
  */
 #ifndef _userConfig_H
@@ -9,8 +9,8 @@
 
 // firmware version (must match with definitions in the main source file)
 #define USR_FW_VERSION    3
-#define USR_FW_SUBVERSION 2
-#define USR_FW_HOTFIX     1
+#define USR_FW_SUBVERSION 3
+#define USR_FW_HOTFIX     0
 #define USR_FW_BRANCH     "ESP8222-MASTER"
 
 // List of supported machines


### PR DESCRIPTION
reset reconnect counter MQTT after succesfull connection. see Issue https://github.com/rancilio-pid/clevercoffee/issues/345
Bring SW Numer to 3.3.0 for new release