### PR TITLE
Upgrade espressif platform and some libraries, switch to esphome fork of ESPAsyncWebserver

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -4,7 +4,7 @@ src_dir = src
 extra_configs = platformio_extra.ini
 
 [env]
-platform = espressif32 @^5
+platform = espressif32 @^6.4.0
 board = az-delivery-devkit-v4
 board_build.filesystem = littlefs
 board_build.partitions = partitions_4M.csv
@@ -17,13 +17,13 @@ lib_deps =
     milesburton/DallasTemperature @ 3.11.0
     paulstoffregen/OneWire @ 2.3.7
     olkal/HX711_ADC @ 1.2.12
-    olikraus/U8g2 @ 2.34.18
+    olikraus/U8g2 @ 2.35.8
     git+https://github.com/rancilio-pid/Arduino-PID-Library#d6d3c69
     knolleary/PubSubClient @ 2.8.0
     me-no-dev/AsyncTCP @ 1.1.1
-    bblanchon/ArduinoJson @ 6.21.3
+    bblanchon/ArduinoJson @ 6.21.4
     tobiasschuerg/ESP8266 Influxdb @ 3.13.1
-    git+https://github.com/me-no-dev/ESPAsyncWebServer#f71e3d4
+    git+https://github.com/esphome/ESPAsyncWebServer#f2a65ff
     git+https://github.com/tzapu/WiFiManager#71937d1
 extra_scripts = pre:auto_firmware_version.py
 


### PR DESCRIPTION
ESPAsyncWebserver doesn't seem to be actively maintained anymore.
The esphome fork seems to have found a solution for the breaking changes introduced with version 5.1 of the espressif platform.

Updating the display and json libs while we're at it.