### PR TITLE
Menu with Rotary Encoder

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -24,6 +24,9 @@ lib_deps =
     git+https://github.com/esphome/AsyncTCP#dc64fed
     git+https://github.com/esphome/ESPAsyncWebServer#f2a65ff
     git+https://github.com/tzapu/WiFiManager#71937d1
+    jomelo/LCDMenuLib2@^2.2.7
+    git+https://github.com/madhephaestus/ESP32Encoder#9979722
+    git+https://github.com/craftmetrics/esp32-button.git#36c6c0a
 extra_scripts = pre:auto_firmware_version.py
 
 [env:esp32_usb]

--- a/src/ISR.cpp
+++ b/src/ISR.cpp
@@ -8,7 +8,6 @@
 #include <Arduino.h>
 #include "ISR.h"
 #include "pinmapping.h"
-#include "userConfig.h"
 
 unsigned int isrCounter = 0;  // counter for ISR
 unsigned long windowStartTime;
@@ -20,13 +19,14 @@ void IRAM_ATTR onTimer(){
 
     if (pidOutput <= isrCounter) {
         digitalWrite(PIN_HEATER, LOW);
-    } else {
+    } 
+    else {
         digitalWrite(PIN_HEATER, HIGH);
     }
 
     isrCounter += 10; // += 10 because one tick = 10ms
 
-    //set PID output as relais commands
+    // Set PID output as relais commands
     if (isrCounter >= windowSize) {
         isrCounter = 0;
     }

--- a/src/ISR.cpp
+++ b/src/ISR.cpp
@@ -19,14 +19,13 @@ void IRAM_ATTR onTimer(){
 
     if (pidOutput <= isrCounter) {
         digitalWrite(PIN_HEATER, LOW);
-    } 
-    else {
+    } else {
         digitalWrite(PIN_HEATER, HIGH);
     }
 
     isrCounter += 10; // += 10 because one tick = 10ms
 
-    // Set PID output as relais commands
+    //set PID output as relais commands
     if (isrCounter >= windowSize) {
         isrCounter = 0;
     }
@@ -41,13 +40,16 @@ void initTimer1(void) {
     timerAlarmWrite(timer, 10000, true);//m
 }
 
+
 void enableTimer1(void) {
     timerAlarmEnable(timer);
 }
 
+
 void disableTimer1(void) {
     timerAlarmDisable(timer);
 }
+
 
 bool isTimer1Enabled(void) {
     return timerAlarmEnabled(timer);

--- a/src/ISR.cpp
+++ b/src/ISR.cpp
@@ -8,6 +8,7 @@
 #include <Arduino.h>
 #include "ISR.h"
 #include "pinmapping.h"
+#include "userConfig.h"
 
 unsigned int isrCounter = 0;  // counter for ISR
 unsigned long windowStartTime;
@@ -31,7 +32,6 @@ void IRAM_ATTR onTimer(){
     }
 }
 
-
 /**
  * @brief Initialize hardware timers
  */
@@ -41,16 +41,13 @@ void initTimer1(void) {
     timerAlarmWrite(timer, 10000, true);//m
 }
 
-
 void enableTimer1(void) {
     timerAlarmEnable(timer);
 }
 
-
 void disableTimer1(void) {
     timerAlarmDisable(timer);
 }
-
 
 bool isTimer1Enabled(void) {
     return timerAlarmEnabled(timer);

--- a/src/ISR.h
+++ b/src/ISR.h
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#include "userConfig.h"
-
 extern unsigned long windowStartTime;
 extern double pidOutput;
 extern unsigned int isrCounter;

--- a/src/ISR.h
+++ b/src/ISR.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include "userConfig.h"
+
 extern unsigned long windowStartTime;
 extern double pidOutput;
 extern unsigned int isrCounter;

--- a/src/defaults.h
+++ b/src/defaults.h
@@ -15,11 +15,11 @@ int factoryReset(void);
 int readSysParamsFromStorage(void);
 int writeSysParamsToStorage(void);
 
-// system parameter defaults and ranges
+// System parameter defaults and ranges
 #define STR_HELPER(x) #x
 #define STR(x) STR_HELPER(x)
 
-// default parameters
+// Default parameters
 #define SETPOINT 95                // brew temperature setpoint
 #define TEMPOFFSET 0               // brew temperature setpoint
 #define STEAMSETPOINT 120          // steam temperature setpoint
@@ -89,31 +89,34 @@ int writeSysParamsToStorage(void);
 #define STANDBY_MODE_TIME_MIN 30
 #define STANDBY_MODE_TIME_MAX 120
 
-
 #if ROTARY_MENU == 1
-#define ENCODER_CLICKS_PER_NOTCH 4
+    #define ENCODER_CLICKS_PER_NOTCH 4
 
-// menu position and size
-#define _LCDML_DISP_box_x0            0              // start point (x0, y0)
-#define _LCDML_DISP_box_y0            0              // start point (x0, y0)
-static const int _LCDML_DISP_box_x1 = SCREEN_WIDTH;  // width x  (x0 + width)
-static const int _LCDML_DISP_box_y1 = SCREEN_HEIGHT; // hight y  (y0 + height)
-#define _LCDML_DISP_scrollbar_w       6  // scrollbar width (if this value is < 3, the scrollbar is disabled)
-#define _LCDML_DISP_cols_max          ((_LCDML_DISP_box_x1-_LCDML_DISP_box_x0)/_LCDML_DISP_font_w)
-#define _LCDML_DISP_rows_max          ((_LCDML_DISP_box_y1-_LCDML_DISP_box_y0-((_LCDML_DISP_box_y1-_LCDML_DISP_box_y0)/_LCDML_DISP_font_h))/_LCDML_DISP_font_h)
-#define _LCDML_DISP_rows              _LCDML_DISP_rows_max  // max rows
-#define _LCDML_DISP_cols              20                   // max cols
-#define _LCDML_DISP_draw_frame 0
+    // Menu position and size
+    #define _LCDML_DISP_box_x0 0
+    #define _LCDML_DISP_box_y0 0
 
-// settings for u8g lib and LCD
-static const int _LCDML_DISP_w = SCREEN_WIDTH; 
-static const int _LCDML_DISP_h = SCREEN_HEIGHT;
-// font settings
-#define _LCDML_DISP_font              u8g_font_6x13  // u8glib font (more fonts under u8g.h line 1520 ...)
-#define _LCDML_DISP_font_w            4              // font width
-#define _LCDML_DISP_font_h            13             // font height
-// cursor settings
-#define _LCDML_DISP_cursor_char       "X"            // cursor char
-#define _LCDML_DISP_cur_space_before  1              // cursor space between
-#define _LCDML_DISP_cur_space_behind  4              // cursor space between
+    static const int _LCDML_DISP_box_x1 = SCREEN_WIDTH;
+    static const int _LCDML_DISP_box_y1 = SCREEN_HEIGHT;
+
+    #define _LCDML_DISP_scrollbar_w 6
+    #define _LCDML_DISP_cols_max ((_LCDML_DISP_box_x1-_LCDML_DISP_box_x0)/_LCDML_DISP_font_w)
+    #define _LCDML_DISP_rows_max ((_LCDML_DISP_box_y1-_LCDML_DISP_box_y0-((_LCDML_DISP_box_y1-_LCDML_DISP_box_y0)/_LCDML_DISP_font_h))/_LCDML_DISP_font_h)
+    #define _LCDML_DISP_rows _LCDML_DISP_rows_max
+    #define _LCDML_DISP_cols 20
+    #define _LCDML_DISP_draw_frame 0
+
+    // Settings for u8g lib and LCD
+    static const int _LCDML_DISP_w = SCREEN_WIDTH; 
+    static const int _LCDML_DISP_h = SCREEN_HEIGHT;
+
+    // Font settings
+    #define _LCDML_DISP_font u8g_font_6x13
+    #define _LCDML_DISP_font_w 4
+    #define _LCDML_DISP_font_h 13
+
+    // Cursor settings
+    #define _LCDML_DISP_cursor_char "X"
+    #define _LCDML_DISP_cur_space_before 2
+    #define _LCDML_DISP_cur_space_behind 4
 #endif

--- a/src/defaults.h
+++ b/src/defaults.h
@@ -89,3 +89,31 @@ int writeSysParamsToStorage(void);
 #define STANDBY_MODE_TIME_MIN 30
 #define STANDBY_MODE_TIME_MAX 120
 
+
+#if ROTARY_MENU == 1
+#define ENCODER_CLICKS_PER_NOTCH 4
+
+// menu position and size
+#define _LCDML_DISP_box_x0            0              // start point (x0, y0)
+#define _LCDML_DISP_box_y0            0              // start point (x0, y0)
+static const int _LCDML_DISP_box_x1 = SCREEN_WIDTH;  // width x  (x0 + width)
+static const int _LCDML_DISP_box_y1 = SCREEN_HEIGHT; // hight y  (y0 + height)
+#define _LCDML_DISP_scrollbar_w       6  // scrollbar width (if this value is < 3, the scrollbar is disabled)
+#define _LCDML_DISP_cols_max          ((_LCDML_DISP_box_x1-_LCDML_DISP_box_x0)/_LCDML_DISP_font_w)
+#define _LCDML_DISP_rows_max          ((_LCDML_DISP_box_y1-_LCDML_DISP_box_y0-((_LCDML_DISP_box_y1-_LCDML_DISP_box_y0)/_LCDML_DISP_font_h))/_LCDML_DISP_font_h)
+#define _LCDML_DISP_rows              _LCDML_DISP_rows_max  // max rows
+#define _LCDML_DISP_cols              20                   // max cols
+#define _LCDML_DISP_draw_frame 0
+
+// settings for u8g lib and LCD
+static const int _LCDML_DISP_w = SCREEN_WIDTH; 
+static const int _LCDML_DISP_h = SCREEN_HEIGHT;
+// font settings
+#define _LCDML_DISP_font              u8g_font_6x13  // u8glib font (more fonts under u8g.h line 1520 ...)
+#define _LCDML_DISP_font_w            4              // font width
+#define _LCDML_DISP_font_h            13             // font height
+// cursor settings
+#define _LCDML_DISP_cursor_char       "X"            // cursor char
+#define _LCDML_DISP_cur_space_before  1              // cursor space between
+#define _LCDML_DISP_cur_space_behind  4              // cursor space between
+#endif

--- a/src/defaults.h
+++ b/src/defaults.h
@@ -89,7 +89,7 @@ int writeSysParamsToStorage(void);
 #define STANDBY_MODE_TIME_MIN 30
 #define STANDBY_MODE_TIME_MAX 120
 
-#if ROTARY_MENU == 1
+#if FEATURE_ROTARY_MENU == 1
     #define ENCODER_CLICKS_PER_NOTCH 4
 
     // Menu position and size

--- a/src/defaults.h
+++ b/src/defaults.h
@@ -111,9 +111,9 @@ int writeSysParamsToStorage(void);
     static const int _LCDML_DISP_h = SCREEN_HEIGHT;
 
     // Font settings
-    #define _LCDML_DISP_font u8g_font_6x13
+    #define _LCDML_DISP_font u8g_font_6x11
     #define _LCDML_DISP_font_w 4
-    #define _LCDML_DISP_font_h 13
+    #define _LCDML_DISP_font_h 11
 
     // Cursor settings
     #define _LCDML_DISP_cursor_char "X"

--- a/src/display.h
+++ b/src/display.h
@@ -291,6 +291,7 @@ void displayToggleBackflushMessage(uint8_t mode) {
     u8g2.clearBuffer();
     u8g2.setCursor(0, 0);
     u8g2.print(LANGSTRING_MENU_BACKFLUSH);
+    
     switch (mode) {
         case 1:
             u8g2.print(LANGSTRING_MENU_ON);
@@ -299,6 +300,7 @@ void displayToggleBackflushMessage(uint8_t mode) {
             u8g2.print(LANGSTRING_MENU_OFF);
             break;
     }
+
     u8g2.setCursor(0, 25);
     u8g2.println(langstring_autoclose[0]);
     u8g2.setCursor(0, 35);
@@ -387,73 +389,66 @@ void displayMenu() {
     uint8_t maxi = _LCDML_DISP_rows + i;
     uint8_t n = 0;
 
-    // init vars
-    uint8_t n_max             = (LCDML.MENU_getChilds() >= _LCDML_DISP_rows) ? _LCDML_DISP_rows : (LCDML.MENU_getChilds());
+    uint8_t n_max = (LCDML.MENU_getChilds() >= _LCDML_DISP_rows) ? _LCDML_DISP_rows : (LCDML.MENU_getChilds());
 
-    uint8_t scrollbar_min     = 0;
-    uint8_t scrollbar_max     = LCDML.MENU_getChilds();
+    uint8_t scrollbar_min = 0;
+    uint8_t scrollbar_max = LCDML.MENU_getChilds();
     uint8_t scrollbar_cur_pos = LCDML.MENU_getCursorPosAbs();
-    uint8_t scroll_pos        = ((1.*n_max * _LCDML_DISP_rows) / (scrollbar_max - 1) * scrollbar_cur_pos);
+    uint8_t scroll_pos = ((1.*n_max * _LCDML_DISP_rows) / (scrollbar_max - 1) * scrollbar_cur_pos);
 
-    // generate content
+    u8g2.setFont(u8g2_font_profont11_tf);
     u8g2.firstPage();
+
     do {
         n = 0;
         i = LCDML.MENU_getScroll();
-        // check if this element has children
+
         if ((tmp = LCDML.MENU_getDisplayedObj()) != NULL) {
-        // loop to display lines
-        do {
-            // check if a menu element has a condition and if the condition be true
-            if (tmp->checkCondition()) {
-            // check the type off a menu element
-            if(tmp->checkType_menu() == true) {
-                // display normal content
-                LCDML_getContent(content_text, tmp->getID());
-                u8g2.drawStr( _LCDML_DISP_box_x0+_LCDML_DISP_font_w + _LCDML_DISP_cur_space_behind, _LCDML_DISP_box_y0 + _LCDML_DISP_font_h * (n + 1), content_text);
-            }
-            else {
-                if(tmp->checkType_dynParam()) {
-                tmp->callback(n);
+            do {
+                if (tmp->checkCondition()) {
+                    if(tmp->checkType_menu() == true) {
+                        LCDML_getContent(content_text, tmp->getID());
+                        u8g2.drawStr( _LCDML_DISP_box_x0+_LCDML_DISP_font_w + _LCDML_DISP_cur_space_behind, _LCDML_DISP_box_y0 + _LCDML_DISP_font_h * (n + 1), content_text);
+                    }
+                    else {
+                        if(tmp->checkType_dynParam()) {
+                            tmp->callback(n);
+                        }
+                    }
+
+                    i++;
+                    n++;
                 }
-            }
-            // increment some values
-            i++;
-            n++;
-            }
-        // try to go to the next sibling and check the number of displayed rows
-        } while (((tmp = tmp->getSibling(1)) != NULL) && (i < maxi));
+            } 
+            while (((tmp = tmp->getSibling(1)) != NULL) && (i < maxi));
         }
 
-        // set cursor
         u8g2.drawStr( _LCDML_DISP_box_x0+_LCDML_DISP_cur_space_before, _LCDML_DISP_box_y0 + _LCDML_DISP_font_h * (LCDML.MENU_getCursorPos() + 1),  _LCDML_DISP_cursor_char);
 
         if(_LCDML_DISP_draw_frame == 1) {
-        u8g2.drawFrame(_LCDML_DISP_box_x0, _LCDML_DISP_box_y0, (_LCDML_DISP_box_x1-_LCDML_DISP_box_x0), (_LCDML_DISP_box_y1-_LCDML_DISP_box_y0));
+            u8g2.drawFrame(_LCDML_DISP_box_x0, _LCDML_DISP_box_y0, (_LCDML_DISP_box_x1-_LCDML_DISP_box_x0), (_LCDML_DISP_box_y1-_LCDML_DISP_box_y0));
         }
 
-        // display scrollbar when more content as rows available and with > 2
-        if (scrollbar_max > n_max && _LCDML_DISP_scrollbar_w > 2)
-        {
-        // set frame for scrollbar
-        u8g2.drawFrame(_LCDML_DISP_box_x1 - _LCDML_DISP_scrollbar_w, _LCDML_DISP_box_y0, _LCDML_DISP_scrollbar_w, _LCDML_DISP_box_y1-_LCDML_DISP_box_y0);
+        if (scrollbar_max > n_max && _LCDML_DISP_scrollbar_w > 2) {
+            // Set frame for scrollbar
+            u8g2.drawFrame(_LCDML_DISP_box_x1 - _LCDML_DISP_scrollbar_w, _LCDML_DISP_box_y0, _LCDML_DISP_scrollbar_w, _LCDML_DISP_box_y1-_LCDML_DISP_box_y0);
 
-        // calculate scrollbar length
-        uint8_t scrollbar_block_length = scrollbar_max - n_max;
-        scrollbar_block_length = (_LCDML_DISP_box_y1-_LCDML_DISP_box_y0) / (scrollbar_block_length + _LCDML_DISP_rows);
+            // Calculate scrollbar length
+            uint8_t scrollbar_block_length = scrollbar_max - n_max;
+            scrollbar_block_length = (_LCDML_DISP_box_y1-_LCDML_DISP_box_y0) / (scrollbar_block_length + _LCDML_DISP_rows);
 
-        //set scrollbar
-        if (scrollbar_cur_pos == 0) {                                   // top position     (min)
-            u8g2.drawBox(_LCDML_DISP_box_x1 - (_LCDML_DISP_scrollbar_w-1), _LCDML_DISP_box_y0 + 1                                                     , (_LCDML_DISP_scrollbar_w-2)  , scrollbar_block_length);
+            if (scrollbar_cur_pos == 0) {                                   // top position     (min)
+                u8g2.drawBox(_LCDML_DISP_box_x1 - (_LCDML_DISP_scrollbar_w-1), _LCDML_DISP_box_y0 + 1 , (_LCDML_DISP_scrollbar_w-2), scrollbar_block_length);
+            }
+            else if (scrollbar_cur_pos == (scrollbar_max-1)) {            // bottom position  (max)
+                u8g2.drawBox(_LCDML_DISP_box_x1 - (_LCDML_DISP_scrollbar_w-1), _LCDML_DISP_box_y1 - scrollbar_block_length, (_LCDML_DISP_scrollbar_w-2), scrollbar_block_length);
+            }
+            else {                                                                // between top and bottom
+                u8g2.drawBox(_LCDML_DISP_box_x1 - (_LCDML_DISP_scrollbar_w-1), _LCDML_DISP_box_y0 + (scrollbar_block_length * scrollbar_cur_pos + 1),(_LCDML_DISP_scrollbar_w-2), scrollbar_block_length);
+            }
         }
-        else if (scrollbar_cur_pos == (scrollbar_max-1)) {            // bottom position  (max)
-            u8g2.drawBox(_LCDML_DISP_box_x1 - (_LCDML_DISP_scrollbar_w-1), _LCDML_DISP_box_y1 - scrollbar_block_length                                , (_LCDML_DISP_scrollbar_w-2)  , scrollbar_block_length);
-        }
-        else {                                                                // between top and bottom
-            u8g2.drawBox(_LCDML_DISP_box_x1 - (_LCDML_DISP_scrollbar_w-1), _LCDML_DISP_box_y0 + (scrollbar_block_length * scrollbar_cur_pos + 1),(_LCDML_DISP_scrollbar_w-2)  , scrollbar_block_length);
-        }
-        }
-    } while ( u8g2.nextPage() );
+    } 
+    while (u8g2.nextPage());
 }
 #endif
 

--- a/src/display.h
+++ b/src/display.h
@@ -270,6 +270,192 @@ void displayShottimer(void) {
     #endif
 }
 
+#if (ROTARY_MENU == 1) 
+
+void displayNumericalMenuSettingWithUnit(double temp, const char* name, const char* unit) {
+    u8g2.clearBuffer();
+    u8g2.setCursor(0, 0);
+    u8g2.print(name);
+    u8g2.print(": ");
+    u8g2.setCursor(0, 10);
+    u8g2.print(temp, 1);
+    u8g2.print(unit);
+    u8g2.setCursor(0, 25);
+    u8g2.println(langstring_pressToSave[0]);
+    u8g2.setCursor(0, 35);
+    u8g2.println(langstring_pressToSave[1]);
+    u8g2.sendBuffer();
+}
+
+void displayToggleBackflushMessage(uint8_t mode) {
+    u8g2.clearBuffer();
+    u8g2.setCursor(0, 0);
+    u8g2.print(LANGSTRING_MENU_BACKFLUSH);
+    switch (mode) {
+        case 1:
+            u8g2.print(LANGSTRING_MENU_ON);
+            break;
+        default:
+            u8g2.print(LANGSTRING_MENU_OFF);
+            break;
+    }
+    u8g2.setCursor(0, 25);
+    u8g2.println(langstring_autoclose[0]);
+    u8g2.setCursor(0, 35);
+    u8g2.println(langstring_autoclose[1]);
+    u8g2.sendBuffer();
+}
+
+void displayMenu() {
+    #if ROTARY_MENU_DEBUG // output menu to serial 
+    // init vars
+    //uint8_t n_max = (LCDML.MENU_getChilds() >= _LCDML_DISP_rows) ? _LCDML_DISP_rows : (LCDML.MENU_getChilds());
+
+    // update content
+    // ***************
+    if (LCDML.DISP_checkMenuUpdate() || LCDML.DISP_checkMenuCursorUpdate() ) {
+        // clear menu
+        // ***************
+        LCDML.DISP_clear();
+
+        debugPrintln(F("==========================================="));
+        debugPrintln(F("================  Menu ===================="));
+        debugPrintln(F("==========================================="));
+
+        // declaration of some variables
+        // ***************
+        // content variable
+        char content_text[_LCDML_DISP_cols];  // save the content text of every menu element
+        // menu element object
+        LCDMenuLib2_menu *tmp;
+        // some limit values
+        uint8_t i = LCDML.MENU_getScroll();
+        uint8_t maxi = (_LCDML_DISP_rows) + i;
+        uint8_t n = 0;
+
+        // check if this element has children
+        if ((tmp = LCDML.MENU_getDisplayedObj()) != NULL)
+        {
+
+        // loop to display lines
+        do
+        {
+            // check if a menu element has a condition and if the condition be true
+            if (tmp->checkCondition())
+            {
+            // display cursor
+            if (n == LCDML.MENU_getCursorPos())
+            {
+                debugPrint(F("(x) "));
+            }
+            else
+            {
+                debugPrint(F("( ) "));
+            }
+
+            // check the type off a menu element
+            if(tmp->checkType_menu() == true)
+            {
+                // display normal content
+                LCDML_getContent(content_text, tmp->getID());
+                debugPrint(content_text);
+            }
+            else
+            {
+                if(tmp->checkType_dynParam()) {
+                tmp->callback(n);
+                }
+            }
+
+            debugPrintln("");
+
+            // increment some values
+            i++;
+            n++;
+            }
+        // try to go to the next sibling and check the number of displayed rows
+        } while (((tmp = tmp->getSibling(1)) != NULL) && (i < maxi));
+        }
+    }
+
+    #endif
+
+
+    char content_text[_LCDML_DISP_cols];  // save the content text of every menu element
+    LCDMenuLib2_menu *tmp;
+    uint8_t i = LCDML.MENU_getScroll();
+    uint8_t maxi = _LCDML_DISP_rows + i;
+    uint8_t n = 0;
+
+    // init vars
+    uint8_t n_max             = (LCDML.MENU_getChilds() >= _LCDML_DISP_rows) ? _LCDML_DISP_rows : (LCDML.MENU_getChilds());
+
+    uint8_t scrollbar_min     = 0;
+    uint8_t scrollbar_max     = LCDML.MENU_getChilds();
+    uint8_t scrollbar_cur_pos = LCDML.MENU_getCursorPosAbs();
+    uint8_t scroll_pos        = ((1.*n_max * _LCDML_DISP_rows) / (scrollbar_max - 1) * scrollbar_cur_pos);
+
+    // generate content
+    u8g2.firstPage();
+    do {
+        n = 0;
+        i = LCDML.MENU_getScroll();
+        // check if this element has children
+        if ((tmp = LCDML.MENU_getDisplayedObj()) != NULL) {
+        // loop to display lines
+        do {
+            // check if a menu element has a condition and if the condition be true
+            if (tmp->checkCondition()) {
+            // check the type off a menu element
+            if(tmp->checkType_menu() == true) {
+                // display normal content
+                LCDML_getContent(content_text, tmp->getID());
+                u8g2.drawStr( _LCDML_DISP_box_x0+_LCDML_DISP_font_w + _LCDML_DISP_cur_space_behind, _LCDML_DISP_box_y0 + _LCDML_DISP_font_h * (n + 1), content_text);
+            }
+            else {
+                if(tmp->checkType_dynParam()) {
+                tmp->callback(n);
+                }
+            }
+            // increment some values
+            i++;
+            n++;
+            }
+        // try to go to the next sibling and check the number of displayed rows
+        } while (((tmp = tmp->getSibling(1)) != NULL) && (i < maxi));
+        }
+
+        // set cursor
+        u8g2.drawStr( _LCDML_DISP_box_x0+_LCDML_DISP_cur_space_before, _LCDML_DISP_box_y0 + _LCDML_DISP_font_h * (LCDML.MENU_getCursorPos() + 1),  _LCDML_DISP_cursor_char);
+
+        if(_LCDML_DISP_draw_frame == 1) {
+        u8g2.drawFrame(_LCDML_DISP_box_x0, _LCDML_DISP_box_y0, (_LCDML_DISP_box_x1-_LCDML_DISP_box_x0), (_LCDML_DISP_box_y1-_LCDML_DISP_box_y0));
+        }
+
+        // display scrollbar when more content as rows available and with > 2
+        if (scrollbar_max > n_max && _LCDML_DISP_scrollbar_w > 2)
+        {
+        // set frame for scrollbar
+        u8g2.drawFrame(_LCDML_DISP_box_x1 - _LCDML_DISP_scrollbar_w, _LCDML_DISP_box_y0, _LCDML_DISP_scrollbar_w, _LCDML_DISP_box_y1-_LCDML_DISP_box_y0);
+
+        // calculate scrollbar length
+        uint8_t scrollbar_block_length = scrollbar_max - n_max;
+        scrollbar_block_length = (_LCDML_DISP_box_y1-_LCDML_DISP_box_y0) / (scrollbar_block_length + _LCDML_DISP_rows);
+
+        //set scrollbar
+        if (scrollbar_cur_pos == 0) {                                   // top position     (min)
+            u8g2.drawBox(_LCDML_DISP_box_x1 - (_LCDML_DISP_scrollbar_w-1), _LCDML_DISP_box_y0 + 1                                                     , (_LCDML_DISP_scrollbar_w-2)  , scrollbar_block_length);
+        }
+        else if (scrollbar_cur_pos == (scrollbar_max-1)) {            // bottom position  (max)
+            u8g2.drawBox(_LCDML_DISP_box_x1 - (_LCDML_DISP_scrollbar_w-1), _LCDML_DISP_box_y1 - scrollbar_block_length                                , (_LCDML_DISP_scrollbar_w-2)  , scrollbar_block_length);
+        }
+        else {                                                                // between top and bottom
+            u8g2.drawBox(_LCDML_DISP_box_x1 - (_LCDML_DISP_scrollbar_w-1), _LCDML_DISP_box_y0 + (scrollbar_block_length * scrollbar_cur_pos + 1),(_LCDML_DISP_scrollbar_w-2)  , scrollbar_block_length);
+        }
+        }
+    } while ( u8g2.nextPage() );
+}
+#endif
 
 /**
  * @brief display heating logo

--- a/src/display.h
+++ b/src/display.h
@@ -292,13 +292,11 @@ void displayToggleMessage(const char* title, uint8_t mode) {
     u8g2.setCursor(0, 0);
     u8g2.print(title);
     
-    switch (mode) {
-        case 1:
-            u8g2.print(LANGSTRING_MENU_ON);
-            break;
-        default:
-            u8g2.print(LANGSTRING_MENU_OFF);
-            break;
+    if (mode == 1) {
+        u8g2.print(LANGSTRING_MENU_ON);
+    }
+    else {
+        u8g2.print(LANGSTRING_MENU_OFF);
     }
 
     u8g2.setCursor(0, 25);

--- a/src/display.h
+++ b/src/display.h
@@ -270,7 +270,7 @@ void displayShottimer(void) {
     #endif
 }
 
-#if (ROTARY_MENU == 1) 
+#if (FEATURE_ROTARY_MENU == 1) 
 
 void displayNumericalMenuSettingWithUnit(double temp, const char* name, const char* unit) {
     u8g2.clearBuffer();

--- a/src/display.h
+++ b/src/display.h
@@ -287,10 +287,10 @@ void displayNumericalMenuSettingWithUnit(double temp, const char* name, const ch
     u8g2.sendBuffer();
 }
 
-void displayToggleBackflushMessage(uint8_t mode) {
+void displayToggleMessage(const char* title, uint8_t mode) {
     u8g2.clearBuffer();
     u8g2.setCursor(0, 0);
-    u8g2.print(LANGSTRING_MENU_BACKFLUSH);
+    u8g2.print(title);
     
     switch (mode) {
         case 1:
@@ -308,149 +308,7 @@ void displayToggleBackflushMessage(uint8_t mode) {
     u8g2.sendBuffer();
 }
 
-void displayMenu() {
-    #if ROTARY_MENU_DEBUG // output menu to serial 
-    // init vars
-    //uint8_t n_max = (LCDML.MENU_getChilds() >= _LCDML_DISP_rows) ? _LCDML_DISP_rows : (LCDML.MENU_getChilds());
-
-    // update content
-    // ***************
-    if (LCDML.DISP_checkMenuUpdate() || LCDML.DISP_checkMenuCursorUpdate() ) {
-        // clear menu
-        // ***************
-        LCDML.DISP_clear();
-
-        debugPrintln(F("==========================================="));
-        debugPrintln(F("================  Menu ===================="));
-        debugPrintln(F("==========================================="));
-
-        // declaration of some variables
-        // ***************
-        // content variable
-        char content_text[_LCDML_DISP_cols];  // save the content text of every menu element
-        // menu element object
-        LCDMenuLib2_menu *tmp;
-        // some limit values
-        uint8_t i = LCDML.MENU_getScroll();
-        uint8_t maxi = (_LCDML_DISP_rows) + i;
-        uint8_t n = 0;
-
-        // check if this element has children
-        if ((tmp = LCDML.MENU_getDisplayedObj()) != NULL)
-        {
-
-        // loop to display lines
-        do
-        {
-            // check if a menu element has a condition and if the condition be true
-            if (tmp->checkCondition())
-            {
-            // display cursor
-            if (n == LCDML.MENU_getCursorPos())
-            {
-                debugPrint(F("(x) "));
-            }
-            else
-            {
-                debugPrint(F("( ) "));
-            }
-
-            // check the type off a menu element
-            if(tmp->checkType_menu() == true)
-            {
-                // display normal content
-                LCDML_getContent(content_text, tmp->getID());
-                debugPrint(content_text);
-            }
-            else
-            {
-                if(tmp->checkType_dynParam()) {
-                tmp->callback(n);
-                }
-            }
-
-            debugPrintln("");
-
-            // increment some values
-            i++;
-            n++;
-            }
-        // try to go to the next sibling and check the number of displayed rows
-        } while (((tmp = tmp->getSibling(1)) != NULL) && (i < maxi));
-        }
-    }
-
-    #endif
-
-
-    char content_text[_LCDML_DISP_cols];  // save the content text of every menu element
-    LCDMenuLib2_menu *tmp;
-    uint8_t i = LCDML.MENU_getScroll();
-    uint8_t maxi = _LCDML_DISP_rows + i;
-    uint8_t n = 0;
-
-    uint8_t n_max = (LCDML.MENU_getChilds() >= _LCDML_DISP_rows) ? _LCDML_DISP_rows : (LCDML.MENU_getChilds());
-
-    uint8_t scrollbar_min = 0;
-    uint8_t scrollbar_max = LCDML.MENU_getChilds();
-    uint8_t scrollbar_cur_pos = LCDML.MENU_getCursorPosAbs();
-    uint8_t scroll_pos = ((1.*n_max * _LCDML_DISP_rows) / (scrollbar_max - 1) * scrollbar_cur_pos);
-
-    u8g2.setFont(u8g2_font_profont11_tf);
-    u8g2.firstPage();
-
-    do {
-        n = 0;
-        i = LCDML.MENU_getScroll();
-
-        if ((tmp = LCDML.MENU_getDisplayedObj()) != NULL) {
-            do {
-                if (tmp->checkCondition()) {
-                    if(tmp->checkType_menu() == true) {
-                        LCDML_getContent(content_text, tmp->getID());
-                        u8g2.drawStr( _LCDML_DISP_box_x0+_LCDML_DISP_font_w + _LCDML_DISP_cur_space_behind, _LCDML_DISP_box_y0 + _LCDML_DISP_font_h * (n + 1), content_text);
-                    }
-                    else {
-                        if(tmp->checkType_dynParam()) {
-                            tmp->callback(n);
-                        }
-                    }
-
-                    i++;
-                    n++;
-                }
-            } 
-            while (((tmp = tmp->getSibling(1)) != NULL) && (i < maxi));
-        }
-
-        u8g2.drawStr( _LCDML_DISP_box_x0+_LCDML_DISP_cur_space_before, _LCDML_DISP_box_y0 + _LCDML_DISP_font_h * (LCDML.MENU_getCursorPos() + 1),  _LCDML_DISP_cursor_char);
-
-        if(_LCDML_DISP_draw_frame == 1) {
-            u8g2.drawFrame(_LCDML_DISP_box_x0, _LCDML_DISP_box_y0, (_LCDML_DISP_box_x1-_LCDML_DISP_box_x0), (_LCDML_DISP_box_y1-_LCDML_DISP_box_y0));
-        }
-
-        if (scrollbar_max > n_max && _LCDML_DISP_scrollbar_w > 2) {
-            // Set frame for scrollbar
-            u8g2.drawFrame(_LCDML_DISP_box_x1 - _LCDML_DISP_scrollbar_w, _LCDML_DISP_box_y0, _LCDML_DISP_scrollbar_w, _LCDML_DISP_box_y1-_LCDML_DISP_box_y0);
-
-            // Calculate scrollbar length
-            uint8_t scrollbar_block_length = scrollbar_max - n_max;
-            scrollbar_block_length = (_LCDML_DISP_box_y1-_LCDML_DISP_box_y0) / (scrollbar_block_length + _LCDML_DISP_rows);
-
-            if (scrollbar_cur_pos == 0) {                                   // top position     (min)
-                u8g2.drawBox(_LCDML_DISP_box_x1 - (_LCDML_DISP_scrollbar_w-1), _LCDML_DISP_box_y0 + 1 , (_LCDML_DISP_scrollbar_w-2), scrollbar_block_length);
-            }
-            else if (scrollbar_cur_pos == (scrollbar_max-1)) {            // bottom position  (max)
-                u8g2.drawBox(_LCDML_DISP_box_x1 - (_LCDML_DISP_scrollbar_w-1), _LCDML_DISP_box_y1 - scrollbar_block_length, (_LCDML_DISP_scrollbar_w-2), scrollbar_block_length);
-            }
-            else {                                                                // between top and bottom
-                u8g2.drawBox(_LCDML_DISP_box_x1 - (_LCDML_DISP_scrollbar_w-1), _LCDML_DISP_box_y0 + (scrollbar_block_length * scrollbar_cur_pos + 1),(_LCDML_DISP_scrollbar_w-2), scrollbar_block_length);
-            }
-        }
-    } 
-    while (u8g2.nextPage());
-}
-#endif
+#endif 
 
 /**
  * @brief display heating logo

--- a/src/languages.h
+++ b/src/languages.h
@@ -37,20 +37,42 @@ static const char *langstring_backflush_press = "Bruehsch. druecken";
 static const char *langstring_backflush_start = "um zu Starten...";
 static const char *langstring_backflush_finish = "zum Beenden...";
 
+// ATTENTION: It is important that none of the displayed strings are longer than 
+// there is columns in the display, otherwise the ESP will crash!
 #define LANGSTRING_MENU_TEMPERATURE "Temperaturen"
 #define LANGSTRING_MENU_BREWSETPOINT "Bruehtemperatur"
 #define LANGSTRING_MENU_STEAMSETPOINT "Dampftemperatur"
 #define LANGSTRING_MENU_BACK "Zurueck"
 #define LANGSTRING_MENU_CLOSE "Menue schliessen"
-#define LANGSTRING_MENU_TIMES "Zeiten"
 #define LANGSTRING_MENU_BREWTIME "Bezugsdauer"
 #define LANGSTRING_MENU_PREINFUSIONTIME "Praeinfusionsdauer"
 #define LANGSTRING_MENU_PREINFUSIONPAUSETIME "Praeinfusionspause"
 #define LANGSTRING_MENU_MACHINESETTINGS "Maschine"
 #define LANGSTRING_MENU_BACKFLUSH "Rueckspuelmodus"
+#define LANGSTRING_MENU_TEMP_OFFSET "Temperaturoffset"
+#define LANGSTRING_MENU_TIMES_AND_WEIGHTS "Zeiten und Gewicht"
+#define LANGSTRING_MENU_WEIGHTSETPOINT "Zielgewicht"
+#define LANGSTRING_MENU_STANDBY_TIMER "Standby Timer"
+#define LANGSTRING_MENU_STANDBY_TIMER_TIME "Standby Time"
+#define LANGSTRING_MENU_PIDPARAMS "PID-Parameter"
+#define LANGSTRING_MENU_PID_KP "PID Kp"
+#define LANGSTRING_MENU_PID_TN "PID Tn"
+#define LANGSTRING_MENU_PID_TV "PID Tv"
+#define LANGSTRING_MENU_PID_I_MAX "PID Integrator Max"
+#define LANGSTRING_MENU_STEAM_KP "Steam Kp"
+#define LANGSTRING_MENU_START_USE_PONM "PonM Start"
+#define LANGSTRING_MENU_START_KP "PonM Start Kp"
+#define LANGSTRING_MENU_START_TN  "PonM Start Tn"
+#define LANGSTRING_MENU_PID_BD_ON "PID Brueherkennung"
+#define LANGSTRING_MENU_PID_BD_DELAY "PID BD Delay"
+#define LANGSTRING_MENU_PID_BD_KP "PID BD Kp"
+#define LANGSTRING_MENU_PID_BD_TN "PID BD Tn"
+#define LANGSTRING_MENU_PID_BD_TV "PID BD Tv"
+#define LANGSTRING_MENU_PID_BD_TIME "PID BD Dauer"
+#define LANGSTRING_MENU_PID_BD_SENSITIVITY "PID BD Sensitiv."
 #define LANGSTRING_MENU_ON "An"
 #define LANGSTRING_MENU_OFF "Aus"
-static const char *langstring_pressToSave[] = {"Button klicken zum ", "Speichern."};
+static const char *langstring_pressToSave[] = {"Klicken zum Speichern,", "Halten zum Abbrechen."};
 static const char *langstring_autoclose[] = {"Menue schliesst sich in", "2 Sekunden automatisch."};
 
 
@@ -83,20 +105,42 @@ static const char *langstring_backflush_press = "Press brew switch";
 static const char *langstring_backflush_start = "to start...";
 static const char *langstring_backflush_finish = "to finish...";
 
+// ATTENTION: It is important that none of the displayed strings are longer than 
+// there is columns in the display, otherwise the ESP will crash!
 #define LANGSTRING_MENU_TEMPERATURE "Temperatures"
 #define LANGSTRING_MENU_BREWSETPOINT "Brew setpoint"
 #define LANGSTRING_MENU_STEAMSETPOINT "Steam setpoint"
 #define LANGSTRING_MENU_BACK "Back"
 #define LANGSTRING_MENU_CLOSE "Close menu"
-#define LANGSTRING_MENU_TIMES "Timings"
 #define LANGSTRING_MENU_BREWTIME "Brewtime"
 #define LANGSTRING_MENU_PREINFUSIONTIME "Preinfusion time"
 #define LANGSTRING_MENU_PREINFUSIONPAUSETIME "Preinfusion pause"
 #define LANGSTRING_MENU_MACHINESETTINGS "Machine Settings"
 #define LANGSTRING_MENU_BACKFLUSH "Backflush mode"
+#define LANGSTRING_MENU_TEMP_OFFSET "Temperature offset"
+#define LANGSTRING_MENU_TIMES_AND_WEIGHTS "Times and weight"
+#define LANGSTRING_MENU_WEIGHTSETPOINT "Target weight"
+#define LANGSTRING_MENU_STANDBY_TIMER "Standby timer"
+#define LANGSTRING_MENU_STANDBY_TIMER_TIME "Standby time"
+#define LANGSTRING_MENU_PIDPARAMS "PID parameters"
+#define LANGSTRING_MENU_PID_KP "PID Kp"
+#define LANGSTRING_MENU_PID_TN "PID Tn"
+#define LANGSTRING_MENU_PID_TV "PID Tv"
+#define LANGSTRING_MENU_PID_I_MAX "PID integrator max"
+#define LANGSTRING_MENU_STEAM_KP "Steam Kp"
+#define LANGSTRING_MENU_START_USE_PONM "PonM Start"
+#define LANGSTRING_MENU_START_KP "PonM Start Kp"
+#define LANGSTRING_MENU_START_TN  "PonM Start Tn"
+#define LANGSTRING_MENU_PID_BD_ON "PID brew detection"
+#define LANGSTRING_MENU_PID_BD_DELAY "PID BD Delay"
+#define LANGSTRING_MENU_PID_BD_KP "PID BD Kp"
+#define LANGSTRING_MENU_PID_BD_TN "PID BD Tn"
+#define LANGSTRING_MENU_PID_BD_TV "PID BD Tv"
+#define LANGSTRING_MENU_PID_BD_TIME "PID BD duration"
+#define LANGSTRING_MENU_PID_BD_SENSITIVITY "PID BD sensitiv."
 #define LANGSTRING_MENU_ON "On"
 #define LANGSTRING_MENU_OFF "Off"
-static const char *langstring_pressToSave[] = {"Press encoder to save", "and return"};
+static const char *langstring_pressToSave[] = {"Click to save or", "hold to abort."};
 static const char *langstring_autoclose[] = {"Menu will autoclose", "in two seconds."};
 
 #elif LANGUAGE == 2 // ES
@@ -128,20 +172,42 @@ static const char *langstring_backflush_press = "Pulsa boton de cafe";
 static const char *langstring_backflush_start = "para empezar...";
 static const char *langstring_backflush_finish = "para terminar...";
 
+// ATTENTION: It is important that none of the displayed strings are longer than 
+// there is columns in the display, otherwise the ESP will crash!
 #define LANGSTRING_MENU_TEMPERATURE "Temperaturas"
 #define LANGSTRING_MENU_BREWSETPOINT "Temperatura de infusión"
 #define LANGSTRING_MENU_STEAMSETPOINT "Temperatura de vapor"
 #define LANGSTRING_MENU_BACK "Back"
 #define LANGSTRING_MENU_CLOSE "Close menu"
-#define LANGSTRING_MENU_TIMES "Timings"
 #define LANGSTRING_MENU_BREWTIME "Brewtime"
 #define LANGSTRING_MENU_PREINFUSIONTIME "Preinfusion time"
 #define LANGSTRING_MENU_PREINFUSIONPAUSETIME "Preinfusion pause"
 #define LANGSTRING_MENU_MACHINESETTINGS "Machine Settings"
 #define LANGSTRING_MENU_BACKFLUSH "Backflush mode"
+#define LANGSTRING_MENU_TEMP_OFFSET "Temperature offset"
+#define LANGSTRING_MENU_TIMES_AND_WEIGHTS "Times and weight"
+#define LANGSTRING_MENU_WEIGHTSETPOINT "Target weight"
+#define LANGSTRING_MENU_STANDBY_TIMER "Standby timer"
+#define LANGSTRING_MENU_STANDBY_TIMER_TIME "Standby time"
+#define LANGSTRING_MENU_PIDPARAMS "PID parameters"
+#define LANGSTRING_MENU_PID_KP "PID Kp"
+#define LANGSTRING_MENU_PID_TN "PID Tn"
+#define LANGSTRING_MENU_PID_TV "PID Tv"
+#define LANGSTRING_MENU_PID_I_MAX "PID integrator max"
+#define LANGSTRING_MENU_STEAM_KP "Steam Kp"
+#define LANGSTRING_MENU_START_USE_PONM "PonM Start"
+#define LANGSTRING_MENU_START_KP "PonM Start Kp"
+#define LANGSTRING_MENU_START_TN  "PonM Start Tn"
+#define LANGSTRING_MENU_PID_BD_ON "PID brew detection"
+#define LANGSTRING_MENU_PID_BD_DELAY "PID BD Delay"
+#define LANGSTRING_MENU_PID_BD_KP "PID BD Kp"
+#define LANGSTRING_MENU_PID_BD_TN "PID BD Tn"
+#define LANGSTRING_MENU_PID_BD_TV "PID BD Tv"
+#define LANGSTRING_MENU_PID_BD_TIME "PID BD duration"
+#define LANGSTRING_MENU_PID_BD_SENSITIVITY "PID BD sensitiv."
 #define LANGSTRING_MENU_ON "On"
 #define LANGSTRING_MENU_OFF "Off"
-static const char *langstring_pressToSave[] = {"Press encoder to save", "and return"};
+static const char *langstring_pressToSave[] = {"Click to save or", "hold to abort."};
 static const char *langstring_autoclose[] = {"Menu will autoclose", "in two seconds."};
 
 #endif

--- a/src/languages.h
+++ b/src/languages.h
@@ -45,9 +45,9 @@ static const char *langstring_backflush_finish = "zum Beenden...";
 #define LANGSTRING_MENU_TIMES "Zeiten"
 #define LANGSTRING_MENU_BREWTIME "Bezugsdauer"
 #define LANGSTRING_MENU_PREINFUSIONTIME "Praeinfusionsdauer"
-#define LANGSTRING_MENU_PREINFUSIONPAUSETIME "Praeinfusion Pause"
+#define LANGSTRING_MENU_PREINFUSIONPAUSETIME "Praeinfusionspause"
 #define LANGSTRING_MENU_MACHINESETTINGS "Maschine"
-#define LANGSTRING_MENU_BACKFLUSH "Backflush-Modus"
+#define LANGSTRING_MENU_BACKFLUSH "Rueckspuelmodus"
 #define LANGSTRING_MENU_ON "An"
 #define LANGSTRING_MENU_OFF "Aus"
 static const char *langstring_pressToSave[] = {"Button klicken zum ", "Speichern."};

--- a/src/languages.h
+++ b/src/languages.h
@@ -37,6 +37,23 @@ static const char *langstring_backflush_press = "Bruehsch. druecken";
 static const char *langstring_backflush_start = "um zu Starten...";
 static const char *langstring_backflush_finish = "zum Beenden...";
 
+#define LANGSTRING_MENU_TEMPERATURE "Temperaturen"
+#define LANGSTRING_MENU_BREWSETPOINT "Bruehtemperatur"
+#define LANGSTRING_MENU_STEAMSETPOINT "Dampftemperatur"
+#define LANGSTRING_MENU_BACK "Zurueck"
+#define LANGSTRING_MENU_CLOSE "Menue schliessen"
+#define LANGSTRING_MENU_TIMES "Zeiten"
+#define LANGSTRING_MENU_BREWTIME "Bezugsdauer"
+#define LANGSTRING_MENU_PREINFUSIONTIME "Praeinfusionsdauer"
+#define LANGSTRING_MENU_PREINFUSIONPAUSETIME "Praeinfusion Pause"
+#define LANGSTRING_MENU_MACHINESETTINGS "Maschine"
+#define LANGSTRING_MENU_BACKFLUSH "Backflush-Modus"
+#define LANGSTRING_MENU_ON "An"
+#define LANGSTRING_MENU_OFF "Aus"
+static const char *langstring_pressToSave[] = {"Button klicken zum ", "Speichern."};
+static const char *langstring_autoclose[] = {"Menue schliesst sich in", "2 Sekunden automatisch."};
+
+
 #elif LANGUAGE == 1 // EN
 #if (DISPLAYTEMPLATE <= 4)
     static const char *langstring_set_temp = "Set:   ";
@@ -66,6 +83,22 @@ static const char *langstring_backflush_press = "Press brew switch";
 static const char *langstring_backflush_start = "to start...";
 static const char *langstring_backflush_finish = "to finish...";
 
+#define LANGSTRING_MENU_TEMPERATURE "Temperatures"
+#define LANGSTRING_MENU_BREWSETPOINT "Brew setpoint"
+#define LANGSTRING_MENU_STEAMSETPOINT "Steam setpoint"
+#define LANGSTRING_MENU_BACK "Back"
+#define LANGSTRING_MENU_CLOSE "Close menu"
+#define LANGSTRING_MENU_TIMES "Timings"
+#define LANGSTRING_MENU_BREWTIME "Brewtime"
+#define LANGSTRING_MENU_PREINFUSIONTIME "Preinfusion time"
+#define LANGSTRING_MENU_PREINFUSIONPAUSETIME "Preinfusion pause"
+#define LANGSTRING_MENU_MACHINESETTINGS "Machine Settings"
+#define LANGSTRING_MENU_BACKFLUSH "Backflush mode"
+#define LANGSTRING_MENU_ON "On"
+#define LANGSTRING_MENU_OFF "Off"
+static const char *langstring_pressToSave[] = {"Press encoder to save", "and return"};
+static const char *langstring_autoclose[] = {"Menu will autoclose", "in two seconds."};
+
 #elif LANGUAGE == 2 // ES
 #if (DISPLAYTEMPLATE <= 4)
     static const char *langstring_set_temp = "Obj:  ";
@@ -94,4 +127,21 @@ static const char *langstring_error_tsensor[] = {"Error, Temp: ", "Comprueba sen
 static const char *langstring_backflush_press = "Pulsa boton de cafe";
 static const char *langstring_backflush_start = "para empezar...";
 static const char *langstring_backflush_finish = "para terminar...";
+
+#define LANGSTRING_MENU_TEMPERATURE "Temperaturas"
+#define LANGSTRING_MENU_BREWSETPOINT "Temperatura de infusión"
+#define LANGSTRING_MENU_STEAMSETPOINT "Temperatura de vapor"
+#define LANGSTRING_MENU_BACK "Back"
+#define LANGSTRING_MENU_CLOSE "Close menu"
+#define LANGSTRING_MENU_TIMES "Timings"
+#define LANGSTRING_MENU_BREWTIME "Brewtime"
+#define LANGSTRING_MENU_PREINFUSIONTIME "Preinfusion time"
+#define LANGSTRING_MENU_PREINFUSIONPAUSETIME "Preinfusion pause"
+#define LANGSTRING_MENU_MACHINESETTINGS "Machine Settings"
+#define LANGSTRING_MENU_BACKFLUSH "Backflush mode"
+#define LANGSTRING_MENU_ON "On"
+#define LANGSTRING_MENU_OFF "Off"
+static const char *langstring_pressToSave[] = {"Press encoder to save", "and return"};
+static const char *langstring_autoclose[] = {"Menu will autoclose", "in two seconds."};
+
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -434,7 +434,7 @@ const unsigned long intervalDisplay = 500;
     #endif
 #endif
 
-#if (ROTARY_MENU == 1)
+#if (FEATURE_ROTARY_MENU == 1)
     #include <LCDMenuLib2.h>
     #include <ESP32Encoder.h> 
     ESP32Encoder encoder;
@@ -2087,7 +2087,7 @@ void setup() {
         #endif
     #endif
 
-    #if(ROTARY_MENU == 1)
+    #if(FEATURE_ROTARY_MENU == 1)
         pinMode(PIN_ROTARY_DT, INPUT_PULLUP);
         pinMode(PIN_ROTARY_CLK, INPUT_PULLUP);
         pinMode(PIN_ROTARY_SW, INPUT_PULLUP);
@@ -2098,7 +2098,7 @@ void setup() {
         setupMenu();
     #endif
 
-    #if(ROTARY_MENU == 1)
+    #if(FEATURE_ROTARY_MENU == 1)
         pinMode(PIN_ROTARY_DT, INPUT_PULLUP);
         pinMode(PIN_ROTARY_CLK, INPUT_PULLUP);
         pinMode(PIN_ROTARY_SW, INPUT_PULLUP);
@@ -2207,7 +2207,7 @@ void setup() {
 void loop() {
     looppid();
 
-    #if ROTARY_MENU == 1
+    #if FEATURE_ROTARY_MENU == 1
         if (!menuOpen) {
             if (xQueueReceive(button_events, &ev, 1/portTICK_PERIOD_MS)) {
                 if (ev.event == BUTTON_UP) {
@@ -2356,7 +2356,7 @@ void looppid() {
 
     // Check if PID should run or not. If not, set to manual and force output to zero
 #if OLED_DISPLAY != 0
-    #if ROTARY_MENU == 1 // only draw the display template if the menu is not open
+    #if FEATURE_ROTARY_MENU == 1 // only draw the display template if the menu is not open
     if (!menuOpen) {
     #endif
         unsigned long currentMillisDisplay = millis();
@@ -2370,7 +2370,7 @@ void looppid() {
         #endif
             printScreen();  // refresh display
         }
-    #if ROTARY_MENU == 1
+    #if FEATURE_ROTARY_MENU == 1
     }
     #endif
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2208,7 +2208,7 @@ void loop() {
     looppid();
 
     #if ROTARY_MENU == 1
-        if (menuOpen == false) {
+        if (!menuOpen) {
             if (xQueueReceive(button_events, &ev, 1/portTICK_PERIOD_MS)) {
                 if (ev.event == BUTTON_UP) {
                     menuOpen = true;
@@ -2220,7 +2220,7 @@ void loop() {
             }
         }
 
-        if (menuOpen == true) {
+        if (menuOpen) {
             LCDML.loop();
         } 
     #endif

--- a/src/menu.h
+++ b/src/menu.h
@@ -5,32 +5,6 @@
  */
 #pragma once
 
-#include "LCDMenuLib2.h"
-#include "Storage.h"
-#include <ESP32Encoder.h>
-#include "button.h"
-#include "defaults.h"
-#include "languages.h"
-#include "debugSerial.h"
-
-extern LCDMenuLib2_menu LCDML_0;
-extern LCDMenuLib2 LCDML;
-extern ESP32Encoder encoder;
-extern button_event_t ev;
-extern QueueHandle_t button_events;
-
-extern double brewSetpoint;
-extern double steamSetpoint;
-extern double brewtime;
-extern double preinfusion;
-extern double preinfusionpause;
-extern int backflushON;
-extern bool menuOpen;
-extern bool clicked;
-
-extern void displayNumericalMenuSettingWithUnit(double temp, const char* name, const char* unit);
-extern void displayToggleBackflushMessage(uint8_t mode);
-
 void displayMenu();
 void clearMenu();
 void menuControls();
@@ -52,97 +26,190 @@ double menuRotaryLast = 0;
 double initialValue = 0;
 int last = 0;
 
-void changeNumericalValue(uint8_t param, double value, sto_item_id_t name, const char* readableName, const char* unit) {
+void changeNumericalSetup(double value, const char* readableName, const char* unit) {
     if(LCDML.FUNC_setup()) {
-        menuRotaryLast = encoder.getCount() / 4;
+        menuRotaryLast = encoder.getCount() / ENCODER_CLICKS_PER_NOTCH;
         initialValue = value;
 
         displayNumericalMenuSettingWithUnit(initialValue, readableName, unit);
     }
+}
+
+void changeNumericalLoop(const char* readableName, const char* unit) {
+    int32_t pos = encoder.getCount() / ENCODER_CLICKS_PER_NOTCH;
+    double diff = static_cast<double>(pos - menuRotaryLast) / 10.0;
+
+    if (diff != 0) {
+        initialValue = initialValue + diff;
+        displayNumericalMenuSettingWithUnit(initialValue, readableName, unit);
+        menuRotaryLast = pos;
+    }
+}
+
+int saveToStorage(sto_item_id_t name) {
+    storageSet(name, initialValue);
+    return storageCommit();
+}
+
+void changeNumericalValue(double* param, double value, sto_item_id_t name, const char* readableName, const char* unit) {
+    changeNumericalSetup(value, readableName, unit);
 
     if(LCDML.FUNC_loop()) {
-        int32_t pos = encoder.getCount() / 4;
-        double diff = static_cast<double>(pos - menuRotaryLast) / 10.0;
-
-        if (diff != 0) {
-            initialValue = initialValue + diff;
-            displayNumericalMenuSettingWithUnit(initialValue, readableName, unit);
-            menuRotaryLast = pos;
-        }
+        changeNumericalLoop(readableName, unit);
             
         if(LCDML.BT_checkEnter()) { 
-            storageSet(name, initialValue);
+            if (saveToStorage(name) == 0) {
+                *param = initialValue;
 
-            int saved = storageCommit();
+                #if ROTARY_MENU_DEBUG == 1
+                    debugPrintln("SAVED.");
+                #endif
 
-            if (saved == 0) {
-                switch (name) {
-                    case STO_ITEM_BREW_SETPOINT:
-                        brewSetpoint = initialValue;
-                        break;
-                    case STO_ITEM_STEAM_SETPOINT:
-                        steamSetpoint = initialValue;
-                        break;
-                    case STO_ITEM_BREW_TIME:
-                        brewtime = initialValue;
-                        break;
-                    case STO_ITEM_PRE_INFUSION_TIME:
-                        preinfusion = initialValue;
-                        break;
-                    case STO_ITEM_PRE_INFUSION_PAUSE:
-                        preinfusionpause = initialValue;
-                        break;
-                    
-                    default:
-                        // do nothing
-                        break;
-                }
-
-                debugPrintln("SAVED.");
                 LCDML.FUNC_goBackToMenu();
             } 
             else {
-                debugPrintln("error.");
+                #if ROTARY_MENU_DEBUG == 1
+                    debugPrintln("error.");
+                #endif
             }
         }
     }
 }
 
 void changeBrewTemp(uint8_t param) {
-    changeNumericalValue(param, brewSetpoint, STO_ITEM_BREW_SETPOINT, LANGSTRING_MENU_BREWSETPOINT, "C");
+    changeNumericalValue(&brewSetpoint, brewSetpoint, STO_ITEM_BREW_SETPOINT, LANGSTRING_MENU_BREWSETPOINT, "C");
 }
 
 void changeSteamTemp(uint8_t param) {
-    changeNumericalValue(param, steamSetpoint, STO_ITEM_STEAM_SETPOINT, LANGSTRING_MENU_BREWSETPOINT, "C");
+    changeNumericalValue(&steamSetpoint, steamSetpoint, STO_ITEM_STEAM_SETPOINT, LANGSTRING_MENU_BREWSETPOINT, "C");
+}
+
+void changeTempOffset(uint8_t param) {
+    changeNumericalValue(&brewTempOffset, brewTempOffset, STO_ITEM_BREW_TEMP_OFFSET, LANGSTRING_MENU_TEMP_OFFSET, "C");
 }
 
 void changeBrewTime(uint8_t param) {
-    changeNumericalValue(param, brewtime, STO_ITEM_BREW_TIME, LANGSTRING_MENU_BREWTIME, "s");
+    changeNumericalValue(&brewTime, brewTime, STO_ITEM_BREW_TIME, LANGSTRING_MENU_BREWTIME, "s");
 }
 
 void changePreinfusionTime(uint8_t param) {
-    changeNumericalValue(param, preinfusion, STO_ITEM_PRE_INFUSION_TIME, LANGSTRING_MENU_PREINFUSIONTIME, "s");
+    changeNumericalValue(&preinfusion, preinfusion, STO_ITEM_PRE_INFUSION_TIME, LANGSTRING_MENU_PREINFUSIONTIME, "s");
 }
 
 void changePreinfusionPauseTime(uint8_t param) {
-    changeNumericalValue(param, preinfusionpause, STO_ITEM_PRE_INFUSION_PAUSE, LANGSTRING_MENU_PREINFUSIONPAUSETIME, "s");
+    changeNumericalValue(&preinfusionPause, preinfusionPause, STO_ITEM_PRE_INFUSION_PAUSE, LANGSTRING_MENU_PREINFUSIONPAUSETIME, "s");
 }
 
-void switchBackflush(uint8_t param) {
+void changeTargetWeight(uint8_t param) {
+    changeNumericalValue(&weightSetpoint, weightSetpoint, STO_ITEM_WEIGHTSETPOINT, LANGSTRING_MENU_WEIGHTSETPOINT, "g");
+}
+
+void changeStandbyTime(uint8_t param) {
+    changeNumericalValue(&standbyModeTime, standbyModeTime, STO_ITEM_STANDBY_MODE_TIME, LANGSTRING_MENU_STANDBY_TIMER_TIME, "min");
+}
+
+void changePidKp(uint8_t param) {
+    changeNumericalValue(&aggKp, aggKp, STO_ITEM_PID_KP_REGULAR, LANGSTRING_MENU_PID_KP, "");
+}
+void changePidTn(uint8_t param) {
+    changeNumericalValue(&aggTn, aggTn, STO_ITEM_PID_TN_REGULAR, LANGSTRING_MENU_PID_TN, "");
+}
+
+void changePidTv(uint8_t param) {
+    changeNumericalValue(&aggTv, aggbTv, STO_ITEM_PID_TV_REGULAR, LANGSTRING_MENU_PID_TV, "");
+}
+
+void changePidIMax(uint8_t param) {
+    changeNumericalValue(&aggIMax, aggIMax, STO_ITEM_PID_I_MAX_REGULAR, LANGSTRING_MENU_PID_I_MAX, "");
+}
+
+void changeSteamKp(uint8_t param) {
+    changeNumericalValue(&steamKp, steamKp, STO_ITEM_PID_KP_STEAM, LANGSTRING_MENU_STEAM_KP, "");
+}
+
+void changePonMKp(uint8_t param) {
+    changeNumericalValue(&startKp, startKp, STO_ITEM_PID_KP_START, LANGSTRING_MENU_START_KP, "");
+    
+}
+void changePonMTn(uint8_t param) {
+    changeNumericalValue(&startTn, startTn, STO_ITEM_PID_TN_START, LANGSTRING_MENU_START_TN, "");
+}
+
+void changeBDDelay(uint8_t param) {
+    changeNumericalValue(&brewPIDDelay, brewPIDDelay, STO_ITEM_BREW_PID_DELAY, LANGSTRING_MENU_PID_BD_DELAY, "s");
+}
+
+void changeBDKp(uint8_t param) {
+    changeNumericalValue(&aggbKp, aggbKp, STO_ITEM_PID_KP_BD, LANGSTRING_MENU_PID_BD_KP, "");
+}
+
+void changeBDTn(uint8_t param) {
+    changeNumericalValue(&aggbTn, aggbTn, STO_ITEM_PID_TN_BD, LANGSTRING_MENU_PID_BD_TN, "");
+}
+
+void changeBDTv(uint8_t param) {
+    changeNumericalValue(&aggbTv, aggbTv, STO_ITEM_PID_TV_BD, LANGSTRING_MENU_PID_BD_TV, "");
+}
+
+void changeBDTime(uint8_t param) {
+    changeNumericalValue(&brewtimesoftware, brewtimesoftware, STO_ITEM_BREW_SW_TIME, LANGSTRING_MENU_PID_BD_TIME, "s");
+}
+
+void changeBDSensitivity(uint8_t param) {
+    changeNumericalValue(&brewSensitivity, brewSensitivity, STO_ITEM_BD_THRESHOLD, LANGSTRING_MENU_PID_BD_SENSITIVITY, "C");
+}
+
+void switchBoolean(uint8_t* flag, uint8_t param, const char* title, sto_item_id_t storageName) {
     if(LCDML.FUNC_setup()) {
-        backflushON = param;
-        displayToggleBackflushMessage(param);
-        delay(2000);
+        param = flipUintValue(param);
+        int saved = storageSet(storageName, param, true);
+
+        if (saved == 0) {
+            *flag = param;
+            #if ROTARY_MENU_DEBUG == 1
+                debugPrintf("Saved %s: %d!\n", title, param);
+            #endif
+        } else {
+            #if ROTARY_MENU_DEBUG == 1
+                debugPrintf("Could not save %s: %d\n", title, saved);
+            #endif
+        }
+
+        // update menu to re-evaluate conditions for showing/hiding menu entries
+        LCDML.MENU_allCondetionRefresh();
+        // if we do not go back to the previous level there are off-by-one cursor issues.... no idea for a fix at the moment
+        LCDML.FUNC_goBackToMenu(1);
+    }
+}
+
+// Special handling for backflush as this setting is not persisted
+void switchBackflush(uint8_t* flag, uint8_t param, const char* title) {
+    if(LCDML.FUNC_setup()) {
+        param = flipUintValue(param);
+        *flag = param;
+        if (param == 1) {
+            displayToggleMessage(title, param);
+            delay(2000);
+            menuOpen = false;
+        }
         LCDML.FUNC_goBackToMenu(1);      
     }
 }
 
-void backflushOn(uint8_t param) {
-    switchBackflush(1);
+void toggleBackflush(uint8_t param) {
+    switchBackflush(&backflushOn, backflushOn, LANGSTRING_MENU_BACKFLUSH);
 }
 
-void backflushOff(uint8_t param) {
-    switchBackflush(0);
+void toggleStandbyTimer(uint8_t param) {
+    switchBoolean(&standbyModeOn, standbyModeOn, LANGSTRING_MENU_STANDBY_TIMER, STO_ITEM_STANDBY_MODE_ON);
+}
+
+void toggleUsePonM(uint8_t param) {
+    switchBoolean(&usePonM, usePonM, LANGSTRING_MENU_START_USE_PONM, STO_ITEM_PID_START_PONM);
+}
+
+void toggleUseBrewPid(uint8_t param) {
+    switchBoolean(&useBDPID, useBDPID, LANGSTRING_MENU_PID_BD_ON, STO_ITEM_USE_BD_PID);
 }
 
 void menuBack(uint8_t param) {
@@ -158,48 +225,126 @@ void menuClose(uint8_t param) {
     }
 }
 
+boolean checkBackflushEnabled() { return backflushOn == 1; }
+boolean checkBackflushDisabled() { return backflushOn == 0; }
+
+boolean checkStandbyEnabled() { return standbyModeOn == 1; }
+boolean checkStandbyDisabled() { return standbyModeOn == 0; }
+
+boolean checkBrewModeScale() { return BREWMODE == 2; }
+
+boolean checkPonMEnabled() { return usePonM == 1; }
+boolean checkPonMDisabled() { return usePonM == 0; }
+
+boolean checkBrewPIDEnabled() { return useBDPID == 1; }
+boolean checkBrewPIDDisabled() { return useBDPID == 0; }
+
+// -------------------
+// Temperatures
+// -------------------
 LCDML_add(0, LCDML_0, 1, LANGSTRING_MENU_TEMPERATURE, NULL); 
 LCDML_add(1, LCDML_0_1, 1, LANGSTRING_MENU_BREWSETPOINT, changeBrewTemp); 
 LCDML_add(2, LCDML_0_1, 2, LANGSTRING_MENU_STEAMSETPOINT, changeSteamTemp); 
-LCDML_add(3, LCDML_0_1, 3, LANGSTRING_MENU_BACK, menuBack); 
+LCDML_add(3, LCDML_0_1, 3, LANGSTRING_MENU_TEMP_OFFSET, changeTempOffset); 
+LCDML_add(4, LCDML_0_1, 4, LANGSTRING_MENU_BACK, menuBack); 
 
-LCDML_add(4, LCDML_0, 2, LANGSTRING_MENU_TIMES, NULL); 
-LCDML_add(5, LCDML_0_2, 1, LANGSTRING_MENU_BREWTIME, changeBrewTime); // NULL = no menu function
-LCDML_add(6, LCDML_0_2, 2, LANGSTRING_MENU_PREINFUSIONTIME, changePreinfusionTime); // NULL = no menu function
-LCDML_add(7, LCDML_0_2, 3, LANGSTRING_MENU_PREINFUSIONPAUSETIME, changePreinfusionPauseTime); 
-LCDML_add(8, LCDML_0_2, 4, LANGSTRING_MENU_BACK, menuBack); 
+// -------------------
+// Times and Weights
+// -------------------
+LCDML_add(5, LCDML_0, 2, LANGSTRING_MENU_TIMES_AND_WEIGHTS, NULL); 
+LCDML_add(6, LCDML_0_2, 1, LANGSTRING_MENU_BREWTIME, changeBrewTime); 
+LCDML_add(7, LCDML_0_2, 2, LANGSTRING_MENU_PREINFUSIONTIME, changePreinfusionTime); 
+LCDML_add(8, LCDML_0_2, 3, LANGSTRING_MENU_PREINFUSIONPAUSETIME, changePreinfusionPauseTime); 
+LCDML_addAdvanced(9, LCDML_0_2, 4, checkBrewModeScale, LANGSTRING_MENU_WEIGHTSETPOINT, changeTargetWeight, 0, _LCDML_TYPE_default); 
+LCDML_add(10, LCDML_0_2, 5, LANGSTRING_MENU_BACK, menuBack); 
 
-LCDML_add(9, LCDML_0, 3, LANGSTRING_MENU_MACHINESETTINGS, NULL); 
-LCDML_add(10, LCDML_0_3, 1, LANGSTRING_MENU_BACKFLUSH, NULL); 
-LCDML_add(11, LCDML_0_3_1, 1, LANGSTRING_MENU_ON, backflushOn); 
-LCDML_add(12, LCDML_0_3_1, 2, LANGSTRING_MENU_OFF, backflushOff); 
-LCDML_add(13, LCDML_0_3_1, 3, LANGSTRING_MENU_BACK, menuBack); 
-LCDML_add(14, LCDML_0_3, 2, LANGSTRING_MENU_BACK, menuBack); 
+// -------------------
+// Machine settings
+// -------------------
+LCDML_add(11, LCDML_0, 3, LANGSTRING_MENU_MACHINESETTINGS, NULL); 
+// BACKFLUSH
+LCDML_add(12, LCDML_0_3, 1, LANGSTRING_MENU_BACKFLUSH, NULL); 
+LCDML_addAdvanced(13, LCDML_0_3_1, 1, checkBackflushDisabled, LANGSTRING_MENU_ON, toggleBackflush, 0, _LCDML_TYPE_default); 
+LCDML_addAdvanced(14, LCDML_0_3_1, 2, checkBackflushEnabled, LANGSTRING_MENU_OFF, toggleBackflush, 0, _LCDML_TYPE_default); 
+LCDML_add(15, LCDML_0_3_1, 3, LANGSTRING_MENU_BACK, menuBack); 
+// STANDBY TIMER
+LCDML_add(16, LCDML_0_3, 2, LANGSTRING_MENU_STANDBY_TIMER, NULL); 
+LCDML_addAdvanced(17, LCDML_0_3_2, 1, checkStandbyDisabled, LANGSTRING_MENU_ON, toggleStandbyTimer, 0, _LCDML_TYPE_default); 
+LCDML_addAdvanced(18, LCDML_0_3_2, 2, checkStandbyEnabled, LANGSTRING_MENU_OFF, toggleStandbyTimer, 0, _LCDML_TYPE_default); 
+LCDML_addAdvanced(19, LCDML_0_3_2, 3, checkStandbyEnabled, LANGSTRING_MENU_STANDBY_TIMER_TIME, changeStandbyTime, 0, _LCDML_TYPE_default); 
+LCDML_add(20, LCDML_0_3_2, 4, LANGSTRING_MENU_BACK, menuBack); 
+LCDML_add(21, LCDML_0_3, 3, LANGSTRING_MENU_BACK, menuBack); 
 
-LCDML_add(15, LCDML_0, 4, LANGSTRING_MENU_CLOSE, menuClose); 
+// -------------------
+// PID Parameters
+// -------------------
+LCDML_add(22, LCDML_0, 4, LANGSTRING_MENU_PIDPARAMS, NULL); 
+LCDML_add(23, LCDML_0_4, 1, LANGSTRING_MENU_PID_KP, changePidKp); 
+LCDML_add(24, LCDML_0_4, 2, LANGSTRING_MENU_PID_TN, changePidTn); 
+LCDML_add(25, LCDML_0_4, 3, LANGSTRING_MENU_PID_TV, changePidTv); 
+LCDML_add(26, LCDML_0_4, 4, LANGSTRING_MENU_PID_I_MAX, changePidIMax); 
+LCDML_add(27, LCDML_0_4, 5, LANGSTRING_MENU_STEAM_KP, changeSteamKp); 
+// PONM
+LCDML_add(28, LCDML_0_4, 6, LANGSTRING_MENU_START_USE_PONM, NULL); 
+LCDML_addAdvanced(29, LCDML_0_4_6, 1, checkPonMDisabled, LANGSTRING_MENU_ON, toggleUsePonM, 0, _LCDML_TYPE_default); 
+LCDML_addAdvanced(30, LCDML_0_4_6, 2, checkPonMEnabled, LANGSTRING_MENU_OFF, toggleUsePonM, 0, _LCDML_TYPE_default); 
+LCDML_addAdvanced(31, LCDML_0_4_6, 3, checkPonMEnabled, LANGSTRING_MENU_START_KP, changePonMKp, 0, _LCDML_TYPE_default); 
+LCDML_addAdvanced(32, LCDML_0_4_6, 4, checkPonMEnabled, LANGSTRING_MENU_START_TN, changePonMTn, 0, _LCDML_TYPE_default); 
+LCDML_add(33, LCDML_0_4_6, 5, LANGSTRING_MENU_BACK, menuBack); 
+// Brew PID
+LCDML_add(34, LCDML_0_4, 7, LANGSTRING_MENU_PID_BD_ON, NULL); 
+LCDML_addAdvanced(35, LCDML_0_4_7, 1, checkBrewPIDDisabled, LANGSTRING_MENU_ON, toggleUseBrewPid, 0, _LCDML_TYPE_default); 
+LCDML_addAdvanced(36, LCDML_0_4_7, 2, checkBrewPIDEnabled, LANGSTRING_MENU_OFF, toggleUseBrewPid, 0, _LCDML_TYPE_default); 
+LCDML_addAdvanced(37, LCDML_0_4_7, 3, checkBrewPIDEnabled, LANGSTRING_MENU_PID_BD_DELAY, changeBDDelay, 0, _LCDML_TYPE_default); 
+LCDML_addAdvanced(38, LCDML_0_4_7, 4, checkBrewPIDEnabled, LANGSTRING_MENU_PID_BD_KP, changeBDKp, 0, _LCDML_TYPE_default); 
+LCDML_addAdvanced(39, LCDML_0_4_7, 5, checkBrewPIDEnabled, LANGSTRING_MENU_PID_BD_TN, changeBDTn, 0, _LCDML_TYPE_default); 
+LCDML_addAdvanced(40, LCDML_0_4_7, 6, checkBrewPIDEnabled, LANGSTRING_MENU_PID_BD_TV, changeBDTv, 0, _LCDML_TYPE_default); 
+LCDML_addAdvanced(41, LCDML_0_4_7, 7, checkBrewPIDEnabled, LANGSTRING_MENU_PID_BD_TIME, changeBDTime, 0, _LCDML_TYPE_default); 
+LCDML_addAdvanced(42, LCDML_0_4_7, 8, checkBrewPIDEnabled, LANGSTRING_MENU_PID_BD_SENSITIVITY, changeBDSensitivity, 0, _LCDML_TYPE_default); 
+LCDML_add(43, LCDML_0_4_7, 9, LANGSTRING_MENU_BACK, menuBack); 
+LCDML_add(44, LCDML_0_4, 8, LANGSTRING_MENU_BACK, menuBack); 
+
+LCDML_add(45, LCDML_0, 5, LANGSTRING_MENU_CLOSE, menuClose); 
 
 // This value has to be the same as the last menu element
-#define _LCDML_DISP_cnt 15
+#define _LCDML_DISP_cnt 45
 LCDML_createMenu(_LCDML_DISP_cnt);
+
+// Menu aborts via longpress have to be "debounced" heavily to feel natural
+long lastMenuAbort = 0;
+long menuAbortInterval = 3000;
 
 // Translate encoder events to menu events
 void menuControls(void) {
-    int32_t pos = encoder.getCount() / 4;
+    int32_t pos = encoder.getCount() / ENCODER_CLICKS_PER_NOTCH;
     if (pos < last) {
         LCDML.BT_up();
-        debugPrintf("Up\n");
+        #if ROTARY_MENU_DEBUG == 1
+            debugPrintf("Up\n");
+        #endif 
     } 
     else if (pos > last) {
         LCDML.BT_down();
-        debugPrintf("Down\n");
+        #if ROTARY_MENU_DEBUG == 1
+            debugPrintf("Down\n");
+        #endif
     } 
     else {
-        if (xQueueReceive(button_events, &ev, 1000/portTICK_PERIOD_MS)) {
-            if (ev.event == BUTTON_DOWN) {
-                debugPrintf("Processing Click");
+        if (xQueueReceive(button_events, &ev, 1/portTICK_PERIOD_MS)) {
+            if (ev.event == BUTTON_UP) {
+                #if ROTARY_MENU_DEBUG == 1
+                    debugPrintf("Processing Click");
+                #endif
                 LCDML.BT_enter();
-            } else {
-                // do nothing
+            } else if (ev.event == BUTTON_HELD) {
+                long abortTime = millis();
+                if (abortTime - lastMenuAbort > menuAbortInterval) {
+                    #if ROTARY_MENU_DEBUG == 1
+                        debugPrintf("Processing button held, aborting.");
+                    #endif
+                    LCDML.FUNC_goBackToMenu(1);
+                    lastMenuAbort = abortTime;
+                }
             }
         }
     }
@@ -212,4 +357,147 @@ void clearMenu() {
 
 void setupMenu() {
     LCDML_setup(_LCDML_DISP_cnt);
+}
+
+void displayMenu() {
+    #if ROTARY_MENU_DEBUG // output menu to serial 
+    // init vars
+    //uint8_t n_max = (LCDML.MENU_getChilds() >= _LCDML_DISP_rows) ? _LCDML_DISP_rows : (LCDML.MENU_getChilds());
+
+    // update content
+    // ***************
+    if (LCDML.DISP_checkMenuUpdate() || LCDML.DISP_checkMenuCursorUpdate() ) {
+        // clear menu
+        // ***************
+        LCDML.DISP_clear();
+
+        debugPrintln(F("==========================================="));
+        debugPrintln(F("================  Menu ===================="));
+        debugPrintln(F("==========================================="));
+
+        // declaration of some variables
+        // ***************
+        // content variable
+        char content_text[_LCDML_DISP_cols];  // save the content text of every menu element
+        // menu element object
+        LCDMenuLib2_menu *tmp;
+        // some limit values
+        uint8_t i = LCDML.MENU_getScroll();
+        uint8_t maxi = (_LCDML_DISP_rows) + i;
+        uint8_t n = 0;
+
+        // check if this element has children
+        if ((tmp = LCDML.MENU_getDisplayedObj()) != NULL)
+        {
+
+        // loop to display lines
+        do
+        {
+            // check if a menu element has a condition and if the condition be true
+            if (tmp->checkCondition())
+            {
+            // display cursor
+            if (n == LCDML.MENU_getCursorPos())
+            {
+                debugPrint(F("(x) "));
+            }
+            else
+            {
+                debugPrint(F("( ) "));
+            }
+
+            // check the type off a menu element
+            if(tmp->checkType_menu() == true)
+            {
+                // display normal content
+                LCDML_getContent(content_text, tmp->getID());
+                debugPrint(content_text);
+            }
+            else
+            {
+                if(tmp->checkType_dynParam()) {
+                tmp->callback(n);
+                }
+            }
+
+            debugPrintln("");
+
+            // increment some values
+            i++;
+            n++;
+            }
+        // try to go to the next sibling and check the number of displayed rows
+        } while (((tmp = tmp->getSibling(1)) != NULL) && (i < maxi));
+        }
+    }
+
+    #endif
+
+
+    char content_text[_LCDML_DISP_cols];  // save the content text of every menu element
+    LCDMenuLib2_menu *tmp;
+    uint8_t i = LCDML.MENU_getScroll();
+    uint8_t maxi = _LCDML_DISP_rows + i;
+    uint8_t n = 0;
+
+    uint8_t n_max = (LCDML.MENU_getChilds() >= _LCDML_DISP_rows) ? _LCDML_DISP_rows : (LCDML.MENU_getChilds());
+
+    uint8_t scrollbar_min = 0;
+    uint8_t scrollbar_max = LCDML.MENU_getChilds();
+    uint8_t scrollbar_cur_pos = LCDML.MENU_getCursorPosAbs();
+    uint8_t scroll_pos = ((1.*n_max * _LCDML_DISP_rows) / (scrollbar_max - 1) * scrollbar_cur_pos);
+
+    u8g2.setFont(u8g2_font_profont11_tf);
+    u8g2.firstPage();
+
+    do {
+        n = 0;
+        i = LCDML.MENU_getScroll();
+
+        if ((tmp = LCDML.MENU_getDisplayedObj()) != NULL) {
+            do {
+                if (tmp->checkCondition()) {
+                    if(tmp->checkType_menu() == true) {
+                        LCDML_getContent(content_text, tmp->getID());
+                        u8g2.drawStr( _LCDML_DISP_box_x0+_LCDML_DISP_font_w + _LCDML_DISP_cur_space_behind, _LCDML_DISP_box_y0 + _LCDML_DISP_font_h * (n + 1), content_text);
+                    }
+                    else {
+                        if(tmp->checkType_dynParam()) {
+                            tmp->callback(n);
+                        }
+                    }
+
+                    i++;
+                    n++;
+                }
+            } 
+            while (((tmp = tmp->getSibling(1)) != NULL) && (i < maxi));
+        }
+
+        u8g2.drawStr( _LCDML_DISP_box_x0+_LCDML_DISP_cur_space_before, _LCDML_DISP_box_y0 + _LCDML_DISP_font_h * (LCDML.MENU_getCursorPos() + 1),  _LCDML_DISP_cursor_char);
+
+        if(_LCDML_DISP_draw_frame == 1) {
+            u8g2.drawFrame(_LCDML_DISP_box_x0, _LCDML_DISP_box_y0, (_LCDML_DISP_box_x1-_LCDML_DISP_box_x0), (_LCDML_DISP_box_y1-_LCDML_DISP_box_y0));
+        }
+
+        if (scrollbar_max > n_max && _LCDML_DISP_scrollbar_w > 2) {
+            // Set frame for scrollbar
+            u8g2.drawFrame(_LCDML_DISP_box_x1 - _LCDML_DISP_scrollbar_w, _LCDML_DISP_box_y0, _LCDML_DISP_scrollbar_w, _LCDML_DISP_box_y1-_LCDML_DISP_box_y0);
+
+            // Calculate scrollbar length
+            uint8_t scrollbar_block_length = scrollbar_max - n_max;
+            scrollbar_block_length = (_LCDML_DISP_box_y1-_LCDML_DISP_box_y0) / (scrollbar_block_length + _LCDML_DISP_rows);
+
+            if (scrollbar_cur_pos == 0) {                                   // top position     (min)
+                u8g2.drawBox(_LCDML_DISP_box_x1 - (_LCDML_DISP_scrollbar_w-1), _LCDML_DISP_box_y0 + 1 , (_LCDML_DISP_scrollbar_w-2), scrollbar_block_length);
+            }
+            else if (scrollbar_cur_pos == (scrollbar_max-1)) {            // bottom position  (max)
+                u8g2.drawBox(_LCDML_DISP_box_x1 - (_LCDML_DISP_scrollbar_w-1), _LCDML_DISP_box_y1 - scrollbar_block_length, (_LCDML_DISP_scrollbar_w-2), scrollbar_block_length);
+            }
+            else {                                                                // between top and bottom
+                u8g2.drawBox(_LCDML_DISP_box_x1 - (_LCDML_DISP_scrollbar_w-1), _LCDML_DISP_box_y0 + (scrollbar_block_length * scrollbar_cur_pos + 1),(_LCDML_DISP_scrollbar_w-2), scrollbar_block_length);
+            }
+        }
+    } 
+    while (u8g2.nextPage());
 }

--- a/src/menu.h
+++ b/src/menu.h
@@ -239,18 +239,14 @@ boolean checkPonMDisabled() { return usePonM == 0; }
 boolean checkBrewPIDEnabled() { return useBDPID == 1; }
 boolean checkBrewPIDDisabled() { return useBDPID == 0; }
 
-// -------------------
 // Temperatures
-// -------------------
 LCDML_add(0, LCDML_0, 1, LANGSTRING_MENU_TEMPERATURE, NULL); 
 LCDML_add(1, LCDML_0_1, 1, LANGSTRING_MENU_BREWSETPOINT, changeBrewTemp); 
 LCDML_add(2, LCDML_0_1, 2, LANGSTRING_MENU_STEAMSETPOINT, changeSteamTemp); 
 LCDML_add(3, LCDML_0_1, 3, LANGSTRING_MENU_TEMP_OFFSET, changeTempOffset); 
 LCDML_add(4, LCDML_0_1, 4, LANGSTRING_MENU_BACK, menuBack); 
 
-// -------------------
 // Times and Weights
-// -------------------
 LCDML_add(5, LCDML_0, 2, LANGSTRING_MENU_TIMES_AND_WEIGHTS, NULL); 
 LCDML_add(6, LCDML_0_2, 1, LANGSTRING_MENU_BREWTIME, changeBrewTime); 
 LCDML_add(7, LCDML_0_2, 2, LANGSTRING_MENU_PREINFUSIONTIME, changePreinfusionTime); 
@@ -258,9 +254,7 @@ LCDML_add(8, LCDML_0_2, 3, LANGSTRING_MENU_PREINFUSIONPAUSETIME, changePreinfusi
 LCDML_addAdvanced(9, LCDML_0_2, 4, checkBrewModeScale, LANGSTRING_MENU_WEIGHTSETPOINT, changeTargetWeight, 0, _LCDML_TYPE_default); 
 LCDML_add(10, LCDML_0_2, 5, LANGSTRING_MENU_BACK, menuBack); 
 
-// -------------------
 // Machine settings
-// -------------------
 LCDML_add(11, LCDML_0, 3, LANGSTRING_MENU_MACHINESETTINGS, NULL); 
 // BACKFLUSH
 LCDML_add(12, LCDML_0_3, 1, LANGSTRING_MENU_BACKFLUSH, NULL); 
@@ -275,9 +269,7 @@ LCDML_addAdvanced(19, LCDML_0_3_2, 3, checkStandbyEnabled, LANGSTRING_MENU_STAND
 LCDML_add(20, LCDML_0_3_2, 4, LANGSTRING_MENU_BACK, menuBack); 
 LCDML_add(21, LCDML_0_3, 3, LANGSTRING_MENU_BACK, menuBack); 
 
-// -------------------
 // PID Parameters
-// -------------------
 LCDML_add(22, LCDML_0, 4, LANGSTRING_MENU_PIDPARAMS, NULL); 
 LCDML_add(23, LCDML_0_4, 1, LANGSTRING_MENU_PID_KP, changePidKp); 
 LCDML_add(24, LCDML_0_4, 2, LANGSTRING_MENU_PID_TN, changePidTn); 
@@ -361,78 +353,54 @@ void setupMenu() {
 
 void displayMenu() {
     #if ROTARY_MENU_DEBUG // output menu to serial 
-    // init vars
-    //uint8_t n_max = (LCDML.MENU_getChilds() >= _LCDML_DISP_rows) ? _LCDML_DISP_rows : (LCDML.MENU_getChilds());
 
     // update content
-    // ***************
     if (LCDML.DISP_checkMenuUpdate() || LCDML.DISP_checkMenuCursorUpdate() ) {
-        // clear menu
-        // ***************
         LCDML.DISP_clear();
 
-        debugPrintln(F("==========================================="));
-        debugPrintln(F("================  Menu ===================="));
-        debugPrintln(F("==========================================="));
-
-        // declaration of some variables
-        // ***************
-        // content variable
-        char content_text[_LCDML_DISP_cols];  // save the content text of every menu element
-        // menu element object
+        char content_text[_LCDML_DISP_cols];  
         LCDMenuLib2_menu *tmp;
-        // some limit values
         uint8_t i = LCDML.MENU_getScroll();
         uint8_t maxi = (_LCDML_DISP_rows) + i;
         uint8_t n = 0;
 
         // check if this element has children
-        if ((tmp = LCDML.MENU_getDisplayedObj()) != NULL)
-        {
+        if ((tmp = LCDML.MENU_getDisplayedObj()) != NULL) {
 
-        // loop to display lines
-        do
-        {
-            // check if a menu element has a condition and if the condition be true
-            if (tmp->checkCondition())
-            {
-            // display cursor
-            if (n == LCDML.MENU_getCursorPos())
-            {
-                debugPrint(F("(x) "));
-            }
-            else
-            {
-                debugPrint(F("( ) "));
-            }
+            // loop to display lines
+            do {
+                // check if a menu element has a condition and if the condition be true
+                if (tmp->checkCondition()) {
+                    // display cursor
+                    if (n == LCDML.MENU_getCursorPos()) {
+                        debugPrint(F("(x) "));
+                    }
+                    else {
+                        debugPrint(F("( ) "));
+                    }
 
-            // check the type off a menu element
-            if(tmp->checkType_menu() == true)
-            {
-                // display normal content
-                LCDML_getContent(content_text, tmp->getID());
-                debugPrint(content_text);
-            }
-            else
-            {
-                if(tmp->checkType_dynParam()) {
-                tmp->callback(n);
+                    // check the type off a menu element
+                    if(tmp->checkType_menu() == true) {
+                        // display normal content
+                        LCDML_getContent(content_text, tmp->getID());
+                        debugPrint(content_text);
+                    }
+                    else {
+                        if(tmp->checkType_dynParam()) {
+                        tmp->callback(n);
+                        }
+                    }
+
+                    debugPrintln("");
+
+                    i++;
+                    n++;
                 }
-            }
-
-            debugPrintln("");
-
-            // increment some values
-            i++;
-            n++;
-            }
-        // try to go to the next sibling and check the number of displayed rows
-        } while (((tmp = tmp->getSibling(1)) != NULL) && (i < maxi));
+            // try to go to the next sibling and check the number of displayed rows
+            } while (((tmp = tmp->getSibling(1)) != NULL) && (i < maxi));
         }
     }
-
     #endif
-
 
     char content_text[_LCDML_DISP_cols];  // save the content text of every menu element
     LCDMenuLib2_menu *tmp;

--- a/src/menu.h
+++ b/src/menu.h
@@ -1,7 +1,11 @@
-#ifndef MENU_H
-#define MENU_H
+/**
+ * @file menu.h
+ * 
+ * @brief Display menu for rotary encoder 
+ */
+#pragma once
 
-#include "LCDMenuLib2.h"  // Include this if LCDMenuLib2.h is not included in the main file
+#include "LCDMenuLib2.h"
 #include "Storage.h"
 #include <ESP32Encoder.h>
 #include "button.h"
@@ -59,6 +63,7 @@ void changeNumericalValue(uint8_t param, double value, sto_item_id_t name, const
     if(LCDML.FUNC_loop()) {
         int32_t pos = encoder.getCount() / 4;
         double diff = static_cast<double>(pos - menuRotaryLast) / 10.0;
+
         if (diff != 0) {
             initialValue = initialValue + diff;
             displayNumericalMenuSettingWithUnit(initialValue, readableName, unit);
@@ -95,15 +100,12 @@ void changeNumericalValue(uint8_t param, double value, sto_item_id_t name, const
 
                 debugPrintln("SAVED.");
                 LCDML.FUNC_goBackToMenu();
-            } else {
+            } 
+            else {
                 debugPrintln("error.");
             }
         }
     }
-
-    // if(LCDML.FUNC_close()) {
-    //     // you can here reset some global vars or do nothing
-    // }
 }
 
 void changeBrewTemp(uint8_t param) {
@@ -176,7 +178,7 @@ LCDML_add(14, LCDML_0_3, 2, LANGSTRING_MENU_BACK, menuBack);
 
 LCDML_add(15, LCDML_0, 4, LANGSTRING_MENU_CLOSE, menuClose); 
 
-// this value has to be the same as the last menu element
+// This value has to be the same as the last menu element
 #define _LCDML_DISP_cnt 15
 LCDML_createMenu(_LCDML_DISP_cnt);
 
@@ -205,14 +207,9 @@ void menuControls(void) {
     last = pos;
 }
 
-
 void clearMenu() {
 }
-
 
 void setupMenu() {
     LCDML_setup(_LCDML_DISP_cnt);
 }
-
-
-#endif  // MENU_H

--- a/src/menu.h
+++ b/src/menu.h
@@ -1,0 +1,218 @@
+#ifndef MENU_H
+#define MENU_H
+
+#include "LCDMenuLib2.h"  // Include this if LCDMenuLib2.h is not included in the main file
+#include "Storage.h"
+#include <ESP32Encoder.h>
+#include "button.h"
+#include "defaults.h"
+#include "languages.h"
+#include "debugSerial.h"
+
+extern LCDMenuLib2_menu LCDML_0;
+extern LCDMenuLib2 LCDML;
+extern ESP32Encoder encoder;
+extern button_event_t ev;
+extern QueueHandle_t button_events;
+
+extern double brewSetpoint;
+extern double steamSetpoint;
+extern double brewtime;
+extern double preinfusion;
+extern double preinfusionpause;
+extern int backflushON;
+extern bool menuOpen;
+extern bool clicked;
+
+extern void displayNumericalMenuSettingWithUnit(double temp, const char* name, const char* unit);
+extern void displayToggleBackflushMessage(uint8_t mode);
+
+void displayMenu();
+void clearMenu();
+void menuControls();
+void changeNumericalValue(uint8_t param, double value, sto_item_id_t name, const char* readableName);
+void changeBrewTemp(uint8_t param);
+void changeSteamTemp(uint8_t param);
+void changeBrewTime(uint8_t param);
+void changePreinfusionTime(uint8_t param);
+void changePreinfusionPauseTime(uint8_t param);
+void switchBackflush(uint8_t param);
+void menuBack(uint8_t param);
+void menuClose(uint8_t param);
+void setupMenu();
+
+LCDMenuLib2_menu LCDML_0(255, 0, 0, NULL, NULL);
+LCDMenuLib2 LCDML(LCDML_0, _LCDML_DISP_rows, _LCDML_DISP_cols, displayMenu, clearMenu, menuControls);
+
+double menuRotaryLast = 0;
+double initialValue = 0;
+int last = 0;
+
+void changeNumericalValue(uint8_t param, double value, sto_item_id_t name, const char* readableName, const char* unit) {
+    if(LCDML.FUNC_setup()) {
+        menuRotaryLast = encoder.getCount() / 4;
+        initialValue = value;
+
+        displayNumericalMenuSettingWithUnit(initialValue, readableName, unit);
+    }
+
+    if(LCDML.FUNC_loop()) {
+        int32_t pos = encoder.getCount() / 4;
+        double diff = static_cast<double>(pos - menuRotaryLast) / 10.0;
+        if (diff != 0) {
+            initialValue = initialValue + diff;
+            displayNumericalMenuSettingWithUnit(initialValue, readableName, unit);
+            menuRotaryLast = pos;
+        }
+            
+        if(LCDML.BT_checkEnter()) { 
+            storageSet(name, initialValue);
+
+            int saved = storageCommit();
+
+            if (saved == 0) {
+                switch (name) {
+                    case STO_ITEM_BREW_SETPOINT:
+                        brewSetpoint = initialValue;
+                        break;
+                    case STO_ITEM_STEAM_SETPOINT:
+                        steamSetpoint = initialValue;
+                        break;
+                    case STO_ITEM_BREW_TIME:
+                        brewtime = initialValue;
+                        break;
+                    case STO_ITEM_PRE_INFUSION_TIME:
+                        preinfusion = initialValue;
+                        break;
+                    case STO_ITEM_PRE_INFUSION_PAUSE:
+                        preinfusionpause = initialValue;
+                        break;
+                    
+                    default:
+                        // do nothing
+                        break;
+                }
+
+                debugPrintln("SAVED.");
+                LCDML.FUNC_goBackToMenu();
+            } else {
+                debugPrintln("error.");
+            }
+        }
+    }
+
+    // if(LCDML.FUNC_close()) {
+    //     // you can here reset some global vars or do nothing
+    // }
+}
+
+void changeBrewTemp(uint8_t param) {
+    changeNumericalValue(param, brewSetpoint, STO_ITEM_BREW_SETPOINT, LANGSTRING_MENU_BREWSETPOINT, "C");
+}
+
+void changeSteamTemp(uint8_t param) {
+    changeNumericalValue(param, steamSetpoint, STO_ITEM_STEAM_SETPOINT, LANGSTRING_MENU_BREWSETPOINT, "C");
+}
+
+void changeBrewTime(uint8_t param) {
+    changeNumericalValue(param, brewtime, STO_ITEM_BREW_TIME, LANGSTRING_MENU_BREWTIME, "s");
+}
+
+void changePreinfusionTime(uint8_t param) {
+    changeNumericalValue(param, preinfusion, STO_ITEM_PRE_INFUSION_TIME, LANGSTRING_MENU_PREINFUSIONTIME, "s");
+}
+
+void changePreinfusionPauseTime(uint8_t param) {
+    changeNumericalValue(param, preinfusionpause, STO_ITEM_PRE_INFUSION_PAUSE, LANGSTRING_MENU_PREINFUSIONPAUSETIME, "s");
+}
+
+void switchBackflush(uint8_t param) {
+    if(LCDML.FUNC_setup()) {
+        backflushON = param;
+        displayToggleBackflushMessage(param);
+        delay(2000);
+        LCDML.FUNC_goBackToMenu(1);      
+    }
+}
+
+void backflushOn(uint8_t param) {
+    switchBackflush(1);
+}
+
+void backflushOff(uint8_t param) {
+    switchBackflush(0);
+}
+
+void menuBack(uint8_t param) {
+    if(LCDML.FUNC_setup()) {
+        LCDML.FUNC_goBackToMenu(1);      
+    }
+}
+
+void menuClose(uint8_t param) {
+    if(LCDML.FUNC_setup()) {
+        LCDML.FUNC_goBackToMenu(1);      
+        menuOpen = false;
+    }
+}
+
+LCDML_add(0, LCDML_0, 1, LANGSTRING_MENU_TEMPERATURE, NULL); 
+LCDML_add(1, LCDML_0_1, 1, LANGSTRING_MENU_BREWSETPOINT, changeBrewTemp); 
+LCDML_add(2, LCDML_0_1, 2, LANGSTRING_MENU_STEAMSETPOINT, changeSteamTemp); 
+LCDML_add(3, LCDML_0_1, 3, LANGSTRING_MENU_BACK, menuBack); 
+
+LCDML_add(4, LCDML_0, 2, LANGSTRING_MENU_TIMES, NULL); 
+LCDML_add(5, LCDML_0_2, 1, LANGSTRING_MENU_BREWTIME, changeBrewTime); // NULL = no menu function
+LCDML_add(6, LCDML_0_2, 2, LANGSTRING_MENU_PREINFUSIONTIME, changePreinfusionTime); // NULL = no menu function
+LCDML_add(7, LCDML_0_2, 3, LANGSTRING_MENU_PREINFUSIONPAUSETIME, changePreinfusionPauseTime); 
+LCDML_add(8, LCDML_0_2, 4, LANGSTRING_MENU_BACK, menuBack); 
+
+LCDML_add(9, LCDML_0, 3, LANGSTRING_MENU_MACHINESETTINGS, NULL); 
+LCDML_add(10, LCDML_0_3, 1, LANGSTRING_MENU_BACKFLUSH, NULL); 
+LCDML_add(11, LCDML_0_3_1, 1, LANGSTRING_MENU_ON, backflushOn); 
+LCDML_add(12, LCDML_0_3_1, 2, LANGSTRING_MENU_OFF, backflushOff); 
+LCDML_add(13, LCDML_0_3_1, 3, LANGSTRING_MENU_BACK, menuBack); 
+LCDML_add(14, LCDML_0_3, 2, LANGSTRING_MENU_BACK, menuBack); 
+
+LCDML_add(15, LCDML_0, 4, LANGSTRING_MENU_CLOSE, menuClose); 
+
+// this value has to be the same as the last menu element
+#define _LCDML_DISP_cnt 15
+LCDML_createMenu(_LCDML_DISP_cnt);
+
+// Translate encoder events to menu events
+void menuControls(void) {
+    int32_t pos = encoder.getCount() / 4;
+    if (pos < last) {
+        LCDML.BT_up();
+        debugPrintf("Up\n");
+    } 
+    else if (pos > last) {
+        LCDML.BT_down();
+        debugPrintf("Down\n");
+    } 
+    else {
+        if (xQueueReceive(button_events, &ev, 1000/portTICK_PERIOD_MS)) {
+            if (ev.event == BUTTON_DOWN) {
+                debugPrintf("Processing Click");
+                LCDML.BT_enter();
+            } else {
+                // do nothing
+            }
+        }
+    }
+
+    last = pos;
+}
+
+
+void clearMenu() {
+}
+
+
+void setupMenu() {
+    LCDML_setup(_LCDML_DISP_cnt);
+}
+
+
+#endif  // MENU_H

--- a/src/userConfig_sample.h
+++ b/src/userConfig_sample.h
@@ -77,7 +77,8 @@ enum MACHINE {
 #define MAXFLUSHCYCLES 5           // number of cycles the backflush should run, 0 = disabled
 
 // Rotary Encoder Menu
-#define ROTARY_MENU 0
+#define ROTARY_MENU 0              // 0 = off, 1 = on
+#define ROTARY_MENU_DEBUG 0        // 0 = off, 1 = on
 
 // PlatformIO OTA
 #define OTA true                   // true = OTA activated, false = OTA deactivated

--- a/src/userConfig_sample.h
+++ b/src/userConfig_sample.h
@@ -76,6 +76,9 @@ enum MACHINE {
 #define FLUSHTIME 10000            // time in ms the 3-way valve is open -> backflush
 #define MAXFLUSHCYCLES 5           // number of cycles the backflush should run, 0 = disabled
 
+// Rotary Encoder Menu
+#define ROTARY_MENU 0
+
 // PlatformIO OTA
 #define OTA true                   // true = OTA activated, false = OTA deactivated
 #define OTAPASS "otapass"          // Password for OTA updates
@@ -94,4 +97,3 @@ enum MACHINE {
 #define EMA_FACTOR 0.6             // Smoothing of input that is used for Tv (derivative component of PID). Smaller means less smoothing but also less delay, 0 means no filtering
 
 #define TEMPSENSOR 2               // Temp sensor type: 1 = DS18B20, 2 = TSIC306
-

--- a/src/userConfig_sample.h
+++ b/src/userConfig_sample.h
@@ -77,7 +77,7 @@ enum MACHINE {
 #define MAXFLUSHCYCLES 5           // number of cycles the backflush should run, 0 = disabled
 
 // Rotary Encoder Menu
-#define ROTARY_MENU 0              // 0 = off, 1 = on
+#define FEATURE_ROTARY_MENU 0              // 0 = off, 1 = on
 #define ROTARY_MENU_DEBUG 0        // 0 = off, 1 = on
 
 // PlatformIO OTA


### PR DESCRIPTION
New PR as I migrated the implementation to a branch in my fork.

- Use ESP32-specific libraries for button and encoder that should use as many of the new fancy functions the platform has to offer as possible, while reducing the need for both timer interrupts and actual interrupts. 
- Cherry-picked fixes/improvements from @fiendie 
- Merged in the latest master 

I've only seen a single temp error since I introduced the changes... The website works smoothly on two clients simultaneously.

TODO:

- [x] Add all other options from the website to the menu
- [ ] Test on other machines :-) 
