### PR TITLE
 Bugfix: Inonsistent Brew & Steam switch behaviours #413 #414

### DIFF
--- a/src/brewscaleini.h
+++ b/src/brewscaleini.h
@@ -25,9 +25,9 @@ enum BrewState {
 BrewState brewcounter = kBrewIdle;
 int brewswitch = 0;
 int brewswitchTrigger = LOW;
-int buttonStateBrewTrigger;                     // the current reading from the input pin
+int lastButtonStateBrewTrigger;                        // the last valid reading from the input pin (debounced)
 unsigned long lastDebounceTimeBrewTrigger = 0;  // the last time the output pin was toggled
-unsigned long debounceDelayBrewTrigger = 50;
+unsigned long debounceDelayBrewTrigger = 20;    // >20ms when switches are "flicked"
 unsigned long brewswitchTriggermillis = 0;
 int brewswitchTriggerCase = 10;
 boolean brewswitchWasOFF = false;
@@ -39,6 +39,7 @@ unsigned long startingTime = 0;                     // start time of brew
 boolean brewPIDdisabled = false;                    // is PID disabled for delay after brew has started?
 const unsigned long analogreadingtimeinterval = 10; // ms
 unsigned long previousMillistempanalogreading;      // ms for analogreading
+const unsigned long brewTriggerLongPress = 500;     // time in ms until brew trigger will be interpreted as manual brewing
 
 // Shot timer with or without scale
 #if (ONLYPIDSCALE == 1 || BREWMODE == 2)

--- a/src/brewvoid.h
+++ b/src/brewvoid.h
@@ -23,22 +23,29 @@ void checkbrewswitch() {
         #if (PIN_BREWSWITCH > 0)
             int reading = digitalRead(PIN_BREWSWITCH);
 
-            if (reading != brewswitchTrigger) {
-                // reset the debouncing timer
+            if (reading != lastButtonStateBrewTrigger) {
+                // restart the debouncing timer
+                #if VERBOSE
+                    if(millis() - lastDebounceTimeBrewTrigger <= debounceDelayBrewTrigger) {
+                        debugPrintf("- No push detected, below debounce: %lu ms <= %lu ms\n", millis() - lastDebounceTimeBrewTrigger, debounceDelayBrewTrigger);
+                    }
+                #endif
                 lastDebounceTimeBrewTrigger = millis();
+                // set new button state 
             }
-
-            if ((millis() - lastDebounceTimeBrewTrigger) > debounceDelayBrewTrigger) {
+            else if ((millis() - lastDebounceTimeBrewTrigger) > debounceDelayBrewTrigger) {
                 // whatever the reading is at, it's been there for longer than the debounce
                 // delay, so take it as the actual current state:
-
-                // if the button state has changed:
-                if (reading != buttonStateBrewTrigger) {
-                    buttonStateBrewTrigger = reading;
+                
+                if (brewswitchTrigger != reading)
+                {
+                    brewswitchTrigger = reading;
+                    #if VERBOSE
+                        debugPrintf("+ Push detected, above debounce: %lu ms > %lu ms\n", millis() - lastDebounceTimeBrewTrigger, debounceDelayBrewTrigger);
+                    #endif
                 }
             }
-
-            brewswitchTrigger = reading;
+            lastButtonStateBrewTrigger = reading;
         #endif
 
         // Convert trigger signal to brew switch state
@@ -60,8 +67,8 @@ void checkbrewswitch() {
                     debugPrintln("brewswitchTriggerCase 20: Brew Trigger HIGH");
                 }
 
-                // Button more than one 1sec pushed
-                if (brewswitchTrigger == HIGH && (brewswitchTriggermillis + 1000 <= millis())) {
+                // Button more than brewTriggerLongPress pushed
+                if (brewswitchTrigger == HIGH && (brewswitchTriggermillis + brewTriggerLongPress  <= millis())) {
                     debugPrintln("brewswitchTriggerCase 20: Manual Trigger - brewing");
                     brewswitchTriggerCase = 31;
                     digitalWrite(PIN_VALVE, relayON);
@@ -73,7 +80,6 @@ void checkbrewswitch() {
                 if ((brewswitchTrigger == HIGH && brewswitch == HIGH) || (machineState == kShotTimerAfterBrew) ) {
                     brewswitch = LOW;
                     brewswitchTriggerCase = 40;
-                    brewswitchTriggermillis = millis();
                     debugPrintln("brewswitchTriggerCase 30: Brew Trigger LOW");
                 }
                 break;
@@ -81,7 +87,6 @@ void checkbrewswitch() {
                 // Stop Manual brewing, button goes low:
                 if (brewswitchTrigger == LOW && brewswitch == LOW) {
                     brewswitchTriggerCase = 40;
-                    brewswitchTriggermillis = millis();
                     debugPrintln("brewswitchTriggerCase 31: Manual Trigger - brewing stop");
                     digitalWrite(PIN_VALVE, relayOFF);
                     digitalWrite(PIN_PUMP, relayOFF);
@@ -89,11 +94,9 @@ void checkbrewswitch() {
             break;
 
             case 40:
-                // wait 5 Sec until next brew, detection
-                if (brewswitchTriggermillis + 5000 <= millis()) {
-                    brewswitchTriggerCase = 10;
-                    debugPrintln("brewswitchTriggerCase 40: Brew Trigger Next Loop");
-                }
+                // Go back to start and wait for brew button press
+                brewswitchTriggerCase = 10;
+                debugPrintln("brewswitchTriggerCase 40: Brew Trigger Next Loop");
                 break;
 
             case 50:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -854,39 +854,6 @@ float filterPressureValue(float input) {
     return inSum;
 }
 
-
-/**
- * @brief steamON & Quickmill
- */
-void checkSteamON() {
-    if (STEAMSWITCHTYPE == 0) {
-        return;
-    }
-
-    // check digital GIPO
-    if (digitalRead(PIN_STEAMSWITCH) == HIGH) {
-        steamON = 1;
-    }
-
-    // if activated via web interface then steamFirstON == 1, prevent override
-    if (digitalRead(PIN_STEAMSWITCH) == LOW && steamFirstON == 0) {
-        steamON = 0;
-    }
-
-    // monitor QuickMill thermoblock steam-mode
-    if (machine == QuickMill) {
-        if (steamQM_active == true) {
-            if (checkSteamOffQM() == true) {  // if true: steam-mode can be turned off
-                steamON = 0;
-                steamQM_active = false;
-                lastTimePVSwasON = 0;
-            } else {
-                steamON = 1;
-            }
-        }
-    }
-}
-
 void setEmergencyStopTemp() {
     if (machineState == kSteam || machineState == kCoolDown) {
         if (EmergencyStopTemp != 145) EmergencyStopTemp = 145;
@@ -1160,7 +1127,7 @@ void handleMachineState() {
         case kShotTimerAfterBrew:
             brewDetection();
 
-            if (millis() - lastbrewTimeMillis > BREWSWITCHDELAY) {
+            if (millis() - lastbrewTimeMillis > SHOTTIMERDISPLAYDELAY) {
                 debugPrintf("Shot time: %4.1f s\n", lastbrewTime / 1000);
                 machineState = kBrewDetectionTrailing;
                 lastbrewTime = 0;
@@ -2241,7 +2208,8 @@ void looppid() {
     #endif
 
     brew();
-    checkSteamON();
+    checkSteamSwitch();
+    checkPowerSwitch();
 
     // set setpoint depending on steam or brew mode
     if (steamON == 1) {
@@ -2251,8 +2219,6 @@ void looppid() {
     }
 
     setEmergencyStopTemp();
-    checkPowerSwitch();
-    checkSteamSwitch();
 
     if (standbyModeOn && machineState != kStandby) {
         updateStandbyTimer();

--- a/src/steamswitchvoid.h
+++ b/src/steamswitchvoid.h
@@ -11,7 +11,7 @@
 int lastSteamSwitchTrigger = LOW;                   // the previous reading from the input pin
 int buttonStateSteamTrigger;                        // the current reading from the input pin
 unsigned long lastDebounceTimeSteamTrigger = 0;     // the last time the output pin was toggled
-unsigned long debounceDelaySteamTrigger = 50;       // the debounce time; increase if the output flickers
+unsigned long debounceDelaySteamTrigger = 20;       // the debounce time; increase if the output flickers
 
 void checkSteamSwitch() {
     #if STEAMSWITCHTYPE == 0
@@ -26,6 +26,20 @@ void checkSteamSwitch() {
         if (digitalRead(PIN_STEAMSWITCH) == LOW && steamFirstON == 0) {
             steamON = 0;
         }
+
+        // monitor QuickMill thermoblock steam-mode
+        if (machine == QuickMill) {
+            if (steamQM_active == true) {
+                if (checkSteamOffQM() == true) {  // if true: steam-mode can be turned off
+                    steamON = 0;
+                    steamQM_active = false;
+                    lastTimePVSwasON = 0;
+                } else {
+                    steamON = 1;
+                }
+            }
+        }
+
     #elif STEAMSWITCHTYPE == 2  // TRIGGER
         int reading = digitalRead(PIN_STEAMSWITCH);
 
@@ -57,4 +71,5 @@ void checkSteamSwitch() {
 
         lastSteamSwitchTrigger = reading;
     #endif
+
 }

--- a/src/userConfig_sample.h
+++ b/src/userConfig_sample.h
@@ -38,7 +38,7 @@ enum MACHINE {
 #define SHOTTIMER 1                // 0 = deactivated, 1 = activated 2 = with scale
 #define HEATINGLOGO 0              // 0 = deactivated, 1 = Rancilio, 2 = Gaggia
 #define OFFLINEGLOGO 1             // 0 = deactivated, 1 = activated
-#define BREWSWITCHDELAY 3000       // time in ms that the brew switch will be delayed (shot timer will show that much longer after switching off)
+#define SHOTTIMERDISPLAYDELAY 3000 // time in ms that shot timer will be shown after brew finished
 #define VERBOSE 0                  // 1 = Show verbose output (serial connection), 0 = show less
 
 #define LANGUAGE 0                 // LANGUAGE = 0 (DE), LANGUAGE = 1 (EN), LANGUAGE = 2 (ES)


### PR DESCRIPTION
Re-do PR with new branch to restore original PR

Brew button was not debounced, leading to erratic behaviour if your switches are not perfect.
5s delay removed, as its not needed (was likely introduced due to erratic behaviour due to bouncing switches)
Fixes https://github.com/rancilio-pid/clevercoffee/issues/413

Steam button configured as push button was twice checked and once not debounced. Removed check in main.cpp. Also migrated missing code to switchvoid file from main to ensure behaviour for switch users stays same.
Fixes https://github.com/rancilio-pid/clevercoffee/issues/416