### PR TITLE
Pin library version of esphome/AsyncTCP

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -20,9 +20,9 @@ lib_deps =
     olikraus/U8g2 @ 2.35.8
     git+https://github.com/rancilio-pid/Arduino-PID-Library#d6d3c69
     knolleary/PubSubClient @ 2.8.0
-    me-no-dev/AsyncTCP @ 1.1.1
     bblanchon/ArduinoJson @ 6.21.4
     tobiasschuerg/ESP8266 Influxdb @ 3.13.1
+    git+https://github.com/esphome/AsyncTCP#dc64fed
     git+https://github.com/esphome/ESPAsyncWebServer#f2a65ff
     git+https://github.com/tzapu/WiFiManager#71937d1
 extra_scripts = pre:auto_firmware_version.py


### PR DESCRIPTION
A recent commit of the esphome-fork of the AsyncTCP library that adds IPv6 support (42a8644bb2fe2e0526a35eeaa6021dd55c1b362c) leads to build errors with the latest version of their fork auf ESPAsyncWebserver. 

Pinning the version of AsyncTCP to 2.0.1 for the time being.
