### PR TITLE
improve mDNS

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -33,7 +33,7 @@ debug_tool = esp-prog
 debug_init_break = tbreak setup
 
 [env:esp32_ota]
-monitor_port = socket://silvia:23
+monitor_port = socket://silvia.local:23
 upload_protocol = espota
-upload_port = silvia
+upload_port = silvia.local
 upload_flags = --auth=otapass

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -112,7 +112,6 @@ unsigned long lastWifiConnectionAttempt = millis();
 unsigned int wifiReconnects = 0;  // actual number of reconnects
 
 // OTA
-const char *OTAhost = OTAHOST;
 const char *OTApass = OTAPASS;
 
 // Backflush values
@@ -2074,7 +2073,7 @@ void setup() {
 
         // OTA Updates
         if (ota && WiFi.status() == WL_CONNECTED) {
-            ArduinoOTA.setHostname(OTAhost);  //  Device name for OTA
+            ArduinoOTA.setHostname(hostname);  //  Device name for OTA
             ArduinoOTA.setPassword(OTApass);  //  Password for OTA
             ArduinoOTA.begin();
         }

--- a/src/userConfig_sample.h
+++ b/src/userConfig_sample.h
@@ -78,7 +78,6 @@ enum MACHINE {
 
 // PlatformIO OTA
 #define OTA true                   // true = OTA activated, false = OTA deactivated
-#define OTAHOST "silvia"           // Name to be shown in Arduino IDE/PlatformIO port
 #define OTAPASS "otapass"          // Password for OTA updates
 
 // MQTT


### PR DESCRIPTION
ArduinoOTA is setting mDNS, so OTAHOST was used to set mDNS Record
mDNS is now hostname.local instead otahost.local
using mDNS for OTA Update and monitoring
website is also reachable through hostname.local

TODO: Discuss -> using the same password for OTA and Wifimanager AP    
                        -> remove posibility to disable ota because mDNS will be turned off aswell
