### PR TITLE
Fix bug in state machine with low water level during backflush

### DIFF
--- a/src/defaults.h
+++ b/src/defaults.h
@@ -44,11 +44,6 @@ int writeSysParamsToStorage(void);
 #define STANDBY_MODE_ON 0          // Standby mode off by default
 #define STANDBY_MODE_TIME 30       // Time in minutes until the heater is turned off   
 
-// Backflush values
-#define FILLTIME 3000              // time in ms the pump is running
-#define FLUSHTIME 6000             // time in ms the 3-way valve is open -> backflush
-#define MAXFLUSHCYCLES 5           // number of cycles the backflush should run, 0 = disabled
-
 #define PID_KP_START_MIN 0
 #define PID_KP_START_MAX 350
 #define PID_TN_START_MIN 0

--- a/src/display.h
+++ b/src/display.h
@@ -184,7 +184,7 @@ void displayLogo(String displaymessagetext, String displaymessagetext2) {
     u8g2.drawStr(0, 45, displaymessagetext.c_str());
     u8g2.drawStr(0, 55, displaymessagetext2.c_str());
 
-    u8g2.drawXBMP(38, 4, CleverCoffee_Logo_width, CleverCoffee_Logo_height, CleverCoffee_Logo);
+    u8g2.drawXBMP(38, 0, CleverCoffee_Logo_width, CleverCoffee_Logo_height, CleverCoffee_Logo);
 
     u8g2.sendBuffer();
 }
@@ -343,23 +343,38 @@ void Displaymachinestate() {
 
     // Backflush
     if (machineState == kBackflush) {
-        u8g2.setFont(u8g2_font_profont11_tf);
-        
-        if (backflushState == 43) {
-            #if OLED_DISPLAY != 0
-                displayMessage(langstring_bckffinished[0], langstring_bckffinished[1], "", "", "", "");
-            #endif
-        } 
-        else if (backflushState == 10) {
-            #if OLED_DISPLAY != 0
-                displayMessage(langstring_bckfactivated[0], langstring_bckfactivated[1], "", "", "", "");
-            #endif
-        } 
-        else if (backflushState > 10) {
-            #if OLED_DISPLAY != 0
-                displayMessage(langstring_bckfrunning[0], String(flushCycles), langstring_bckfrunning[1], String(maxflushCycles), "", "");
-            #endif
+        u8g2.clearBuffer();
+        u8g2.setFont(u8g2_font_fub17_tf);
+        u8g2.setCursor(2, 10);
+        u8g2.print("Backflush");
+
+        switch (backflushState) {
+            case kBackflushWaitBrewswitchOn:
+                u8g2.setFont(u8g2_font_profont12_tf);
+                u8g2.setCursor(4, 37);
+                u8g2.print(langstring_backflush_press);
+                u8g2.setCursor(4, 50);
+                u8g2.print(langstring_backflush_start);
+                break;
+
+            case kBackflushWaitBrewswitchOff:
+                u8g2.setFont(u8g2_font_profont12_tf);
+                u8g2.setCursor(4, 37);
+                u8g2.print(langstring_backflush_press);
+                u8g2.setCursor(4, 50);
+                u8g2.print(langstring_backflush_finish);
+                break;
+
+            default:
+                u8g2.setFont(u8g2_font_fub17_tf);
+                u8g2.setCursor(42, 42);
+                u8g2.print(flushCycles + 1, 0);
+                u8g2.print("/");
+                u8g2.print(maxflushCycles, 0);
+                break;
         }
+
+        u8g2.sendBuffer();
     }
 
     // PID Off

--- a/src/languages.h
+++ b/src/languages.h
@@ -33,9 +33,9 @@ static const char *langstring_nowifi[] = {"Kein ", "WLAN"};
 static const char *langstring_error_tsensor[] = {"Fehler, Temp: ", "Temp.-Sensor ueberpruefen!"};
 // static const char *langstring_emergencyStop[] = {"HEATING", "STOPPED"};
 
-static const char *langstring_bckffinished[] = {"Backflush beendet", "Bitte Bruehschalter abschalten..."};
-static const char *langstring_bckfactivated[] = {"Backflush aktiviert", "Bruehschalter betaetigen ..."};
-static const char *langstring_bckfrunning[] = {"Backflush aktiv:", "seit"};
+static const char *langstring_backflush_press = "Bruehsch. druecken";
+static const char *langstring_backflush_start = "um zu Starten...";
+static const char *langstring_backflush_finish = "zum Beenden...";
 
 #elif LANGUAGE == 1 // EN
 #if (DISPLAYTEMPLATE <= 4)
@@ -62,9 +62,9 @@ static const char *langstring_nowifi[] = {"No ", "WIFI"};
 static const char *langstring_error_tsensor[] = {"Error, Temp: ", "Check Temp. sensor!"};
 // static const char *langstring_emergencyStop[] = {"HEATING", "STOPPED"};
 
-static const char *langstring_bckffinished[] = {"Backflush finished", "Please reset brew switch..."};
-static const char *langstring_bckfactivated[] = {"Backflush activated", "Please set brew switch..."};
-static const char *langstring_bckfrunning[] = {"Backflush running:", "from"};
+static const char *langstring_backflush_press = "Press brew switch";
+static const char *langstring_backflush_start = "to start...";
+static const char *langstring_backflush_finish = "to finish...";
 
 #elif LANGUAGE == 2 // ES
 #if (DISPLAYTEMPLATE <= 4)
@@ -91,7 +91,7 @@ static const char *langstring_nowifi[] = {"No ", "WIFI"};
 static const char *langstring_error_tsensor[] = {"Error, Temp: ", "Comprueba sensor T!"};
 // static const char *langstring_emergencyStop[] = {"CALENT.", "PARADO "};
 
-static const char *langstring_bckffinished[] = {"Backflush terminado", "Apague el boton de cafe..."};
-static const char *langstring_bckfactivated[] = {"Backflush activado ", "Encienda boton de cafe.."};
-static const char *langstring_bckfrunning[] = {"Backflush activo: ", "desde"};
+static const char *langstring_backflush_press = "Pulsa boton de cafe";
+static const char *langstring_backflush_start = "para empezar...";
+static const char *langstring_backflush_finish = "para terminar...";
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -249,7 +249,7 @@ boolean setupDone = false;
 int backflushOn = 0;                            // 1 = backflush mode active
 int flushCycles = 0;                            // number of active flush cycles
 
-int backflushState = kBackflushWaitBrewswitchOn;
+int backflushState = 10;
 
 // Water sensor
 boolean waterFull = true;

--- a/src/userConfig_sample.h
+++ b/src/userConfig_sample.h
@@ -68,6 +68,11 @@ enum MACHINE {
 #define SCALE_SAMPLES 2                     // Load cell sample rate
 #define SCALE_CALIBRATION_FACTOR 3195.83    // Raw data is divided by this value to convert to readable data
 
+// Backflush values
+#define FILLTIME 5000              // time in ms the pump is running
+#define FLUSHTIME 10000            // time in ms the 3-way valve is open -> backflush
+#define MAXFLUSHCYCLES 5           // number of cycles the backflush should run, 0 = disabled
+
 /* Pressure sensor
  *
  * measure and verify "offset" value, should be 10% of ADC bit reading @supply volate (3.3V)


### PR DESCRIPTION
When the water level is low during backflush the pump would keep running because the state machine would go to kWaterEmpty without deactivating backflush mode