### PR TITLE
 Fix: Backflush not possible to abort for "Brew-Trigger" Switches

### DIFF
--- a/src/brewvoid.h
+++ b/src/brewvoid.h
@@ -137,9 +137,11 @@ void checkbrewswitch() {
             break;
 
             case 40:
-                // Go back to start and wait for brew button press
-                brewSwitchTriggerCase = 10;
-                debugPrintln("brewSwitchTriggerCase 40: Brew Trigger Next Loop");
+                // Once Toggle-Button is released, go back to start and wait for brew button press
+                if (brewSwitchTrigger == LOW) {
+                    brewSwitchTriggerCase = 10;
+                    debugPrintln("brewSwitchTriggerCase 40: Brew Trigger Next Loop");
+                }
                 break;
 
             case 50:

--- a/src/display.h
+++ b/src/display.h
@@ -374,6 +374,7 @@ void Displaymachinestate() {
                 break;
         }
 
+        displayWaterIcon(119, 1);
         u8g2.sendBuffer();
     }
 


### PR DESCRIPTION
Fix: Backflush for Brewtrigger was immediately restarted when trying to abort.
Water-Empty-Icon shown while Backflush runs and water gets empty.