### PR TITLE
RGB LEDs as state indicators with animations, cup illumination, etc 

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -24,6 +24,7 @@ lib_deps =
     git+https://github.com/esphome/AsyncTCP#dc64fed
     git+https://github.com/esphome/ESPAsyncWebServer#f2a65ff
     git+https://github.com/tzapu/WiFiManager#71937d1
+    fastled/FastLED @ 3.6.0
 extra_scripts = pre:auto_firmware_version.py
 
 [env:esp32_usb]

--- a/src/brewHandler.h
+++ b/src/brewHandler.h
@@ -343,6 +343,9 @@ void brew() {
                 brewCounter = kWaitBrewOff;
                 timeBrewed = 0;
 
+                //LED illuminates coffee
+                brewFinishedLEDon = BREW_FINISHED_LEDON_DURATION;
+
                 break;
 
             case kWaitBrewOff:  // waiting for brewswitch off position
@@ -355,6 +358,12 @@ void brew() {
                     brewDetected = 0;  // rearm brewDetection
                     brewCounter = kBrewIdle;
                     timeBrewed = 0;
+
+                    //LED illuminates coffee
+                    if (brewFinishedLEDon==0) 
+                    {
+                        brewFinishedLEDon = BREW_FINISHED_LEDON_DURATION;
+                    }
                 }
 
                 break;

--- a/src/display/displayTemplateMinimal.h
+++ b/src/display/displayTemplateMinimal.h
@@ -34,8 +34,8 @@ void printScreen() {
                 numDecimalsSetpoint = 0;
             }
 
-            // Draw temp, blink if TEMP_LED is not enabled
-            if ((fabs(temperature - setpoint) < 0.3) && !FEATURE_TEMP_LED) {
+            // Draw temp, blink if FEATURE_STATUS_LED is not enabled
+            if ((fabs(temperature - setpoint) < 0.3) && !FEATURE_STATUS_LED) {
                 if (isrCounter < 500) {
                     // limit to 4 characters
                     u8g2.setCursor(2, 20);

--- a/src/display/displayTemplateTempOnly.h
+++ b/src/display/displayTemplateTempOnly.h
@@ -26,7 +26,7 @@ void printScreen() {
 
             // draw (blinking) temp
             if (((fabs(temperature - setpoint) < blinkingtempoffset && blinkingtemp == 0) ||
-                (fabs(temperature - setpoint) >= blinkingtempoffset && blinkingtemp == 1)) && !FEATURE_TEMP_LED) {
+                (fabs(temperature - setpoint) >= blinkingtempoffset && blinkingtemp == 1)) && !FEATURE_STATUS_LED) {
                 if (isrCounter < 500) {
                     if (temperature < 99.999) {
                         u8g2.setCursor(8, 22);

--- a/src/hardware/statusLED.h
+++ b/src/hardware/statusLED.h
@@ -1,0 +1,119 @@
+/**
+ * @file StatusLED.h
+ *
+ * @brief Implementation of LED behaviour
+ */
+
+#pragma once
+
+unsigned long brightnessLED;
+
+void statusLEDSetup() {
+    #if FEATURE_STATUS_LED == 1
+        #if STATUS_LED_TYPE == 0
+            pinMode(PIN_STATUSLED, OUTPUT);
+        #elif STATUS_LED_TYPE == 1
+            FastLED.addLeds<RGB_LED_TYPE, PIN_STATUSLED>(leds, RGB_LED_NUM);
+        #endif
+    #endif
+}
+
+void loopLED() {
+#if STATUS_LED_TYPE == 0
+    //analog LED
+    if ((machineState == kPidNormal && (fabs(temperature  - setpoint) < 0.3)) || (temperature > 115 && fabs(temperature - setpoint) < 5)) {
+        digitalWrite(PIN_STATUSLED, HIGH);
+    }
+    else {
+        digitalWrite(PIN_STATUSLED, LOW);
+    }
+#endif
+
+#if STATUS_LED_TYPE == 1
+    unsigned long currentMillisLED = millis();
+
+    if (currentMillisLED - previousMillisLED >= intervalLED) {
+        previousMillisLED = currentMillisLED;
+
+        // Color cycle variable
+        cycleLED++;
+        
+        if (cycleLED >= 255) {
+            cycleLED = 0;
+        }
+
+        // Standby -> Switch LEDs off, but overwrite with other states
+        fill_solid(leds, RGB_LED_NUM, CRGB::Black); 
+
+        if (machineState == kPidNormal) {        
+            // PID heating (no standby) - white 20% low brightness 
+            fill_solid(leds, RGB_LED_NUM, CHSV(0,0,RGB_LED_PIDON_BRIGHTNESS));
+
+            if ((fabs(temperature  - setpoint) < 0.3) || (temperature > 115 && fabs(temperature - setpoint) < 5)) { 
+                // Correct temp for both Brew and Steam -> Green in back of machine
+                leds[0] = CRGB::DarkGreen; 
+            }            
+        }
+
+        // [For LED_BEHAVIOUR 2]:
+        if (RGB_LED_BEHAVIOUR == 2) {
+
+            // Brew coffee -> White, preinfusion a bit toned down
+            if (machineState == kBrew || brewSwitchTriggerCase == 31) {
+
+                if (brewCounter >= kBrewRunning) {
+                    fill_solid(leds, RGB_LED_NUM, CRGB::White); 
+                }
+                else {
+                    // during preinfusion, put 40% brightness white
+                    fill_solid(leds, RGB_LED_NUM, CHSV(0, 0, 100));
+                }
+            }
+
+            // Set higher temperature for Steam -> dark yellow (if not at correct temperature)
+            if (machineState == kSteam && !(temperature > 115 && fabs(temperature - setpoint) < 5) ) {
+                fill_solid(leds, RGB_LED_NUM, CHSV(45, 255, 100)); // 45 is yellow, 100 is 40% brighteness
+            }
+
+            // Initialize & Heat up --> Rainbow
+            if (machineState == kInit || machineState == kColdStart) {
+                for (int i = 0; i < RGB_LED_NUM; i++) {
+                    leds[i] = CHSV(i * 32 - (cycleLED * 2), 255, 255); // Hue, saturation, brightness
+                }
+            }   
+        }
+
+        // Backflush -> White
+        if (machineState == kBackflush) {
+            fill_solid(leds, RGB_LED_NUM, CRGB::White); 
+        }        
+
+        // After coffee is brewed -> White light to show ready coffee for ~15s
+        if (brewFinishedLEDon > 0) {
+            brewFinishedLEDon--;
+            // for the last 10% of the time, smoothly dim down white light on cup
+            brightnessLED = (brewFinishedLEDon > (BREW_FINISHED_LEDON_DURATION / 10) ? 200 : 150 * brewFinishedLEDon * 10 / BREW_FINISHED_LEDON_DURATION + RGB_LED_PIDON_BRIGHTNESS);
+            fill_solid(leds, RGB_LED_NUM, CHSV(0, 0, brightnessLED)); 
+        }
+        
+        // Error message: Red (Water empty, sensor error, etc) - overrides all other states in LED color
+        if (!waterFull || machineState == kSensorError || machineState ==  kEepromError || machineState ==  kEmergencyStop) {
+            if (RGB_LED_BEHAVIOUR == 2) {
+                // [For LED_BEHAVIOUR 2]: Red heartbeat
+                fill_solid(leds, RGB_LED_NUM, CHSV(0, 250, cubicwave8(cycleLED * 4))); //Hue of 0 is red
+
+                if (RGB_LED_NUM > 1) {
+                    fill_solid(leds + RGB_LED_NUM / 2, RGB_LED_NUM - RGB_LED_NUM / 2, CHSV(0, 250, cubicwave8(128 + cycleLED * 4))); //Hue of 0 is red
+                }
+            }
+            else {
+                // [For LED_BEHAVIOUR 1]: Solid red color
+                fill_solid(leds, RGB_LED_NUM, CRGB::Red); 
+            }
+        }
+        
+        FastLED.show(); 
+    }
+#endif
+
+}

--- a/src/userConfig_sample.h
+++ b/src/userConfig_sample.h
@@ -62,10 +62,17 @@ enum MACHINE {
 #define STEAMSWITCH_TYPE 0         // 0 = no switch connected, 1 = normal switch, 2 = trigger switch
 #define OPTOCOUPLER_TYPE HIGH      // BREWDETECTION 3 configuration; HIGH or LOW trigger optocoupler
 #define TRIGGER_TYPE HIGH          // LOW = low trigger, HIGH = high trigger relay for pump & valve
-#define FEATURE_TEMP_LED 0         // Blink status LED when temp is in range, 0 = deactivated, 1 = activated
 #define FEATURE_WATER_SENS 0       // 0 = deactivated, 1 = activated
 #define WATER_SENS_TYPE 0          // 0 = water sensor XKC-Y25-NPN connected, 1 = XKC-Y25-PNP connected
 #define FEATURE_PRESSURESENSOR 0   // 0 = deactivated, 1 = activated
+
+// Status LED
+#define FEATURE_STATUS_LED 0       // Status LED, 0 = deactivated, 1 = activated
+#define STATUS_LED_TYPE 0          // 0 = single color LED to blink when temp in range, 1 = RGB adressable LED with LED_BEHAVIOUR set below
+#define RGB_LED_BEHAVIOUR 2        // 1 = Basic: Brewed-white, Error-red, TempOK-green; 2 = same as Basic, plus: Brewing-blue, Startup-Rainbow, Steam-Yellow, Backflush-white
+#define RGB_LED_TYPE WS2811        // In case of an RGB LED so STATUS_LED_TYPE==2, state type of LED (NEOPIXEL, WS2811, TM1809, ...)
+#define RGB_LED_NUM 4              // Number of LEDs attached. Not considered if FEATURE_STATUS_LED above is zero
+#define RGB_LED_PIDON_BRIGHTNESS 50// Brightness from 0-255 for the cup illumination when machine is on
 
 // Brew Scale
 #define SCALE_SAMPLES 2            // Load cell sample rate


### PR DESCRIPTION
Added FastLED library, and LED handling for Neopixels with e.g. WS2811 chip.
LoopLED will be called every 80ms for relatively smooth LED animations.
Number of LEDs and chip type is freely configurable.
Library is using Hardware features of ESP32 to avoid interrup conflicts
2 LED behaviours added to select from: Basic & Plus

LED behaviour "Basic" 
Perfect temp -> Green, one LED in back of machine
Backflush -> white
After coffee is brewed -> white 
Error -> red

LED behaviour "Plus" :
PINon (not standby) -> low brightness white
Perfect temp -> Green, one LED in back of machine
Brew/Steam/Backflush -> white
After coffee is brewed -> White light to show ready coffee for 15s, for the last 10% of the time, smoothly dim down
Initialize, cold start Heat up -> Rainbow (only if configured)
Error message -> Red heartbeat (Water empty, sensor error, etc) 
Steam-heat-up -> yellow