### PR TITLE
fix wrong bootstrap digest

### DIFF
--- a/src/embeddedWebserver.h
+++ b/src/embeddedWebserver.h
@@ -179,7 +179,7 @@ String getHeader(String varName) {
             #if NOINTERNET == 1
                 return F("<link href=\"/css/bootstrap-5.2.3.min.css\" rel=\"stylesheet\">");
             #else
-                return F("<link href=\"https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css\" rel=\"stylesheet\" integrity=\"sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3\" crossorigin=\"anonymous\">");
+                return F("<link href=\"https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css\" rel=\"stylesheet\" integrity=\"sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65\" crossorigin=\"anonymous\">");
             #endif
         case (str2int("BOOTSTRAP_BUNDLE")):
             #if NOINTERNET == 1


### PR DESCRIPTION
When enabling nointernet mode, the bootstrap css wasn't loaded because the integrity hash was wrong.