### PR TITLE
Bugfix: Backflush not stopping when Brew-trigger configured

### DIFF
--- a/src/brewHandler.h
+++ b/src/brewHandler.h
@@ -126,7 +126,7 @@ void checkbrewswitch() {
 
             case 30:
                 // Stop brew trigger (one push) brewswitch == HIGH
-                if ((brewSwitchTrigger == HIGH && brewSwitch == HIGH) || (machineState == kShotTimerAfterBrew) ) {
+                if ((brewSwitchTrigger == HIGH && brewSwitch == HIGH) || (machineState == kShotTimerAfterBrew) || (backflushState == kBackflushWaitBrewswitchOff)) {
                     brewSwitch = LOW;
                     brewSwitchTriggerCase = 40;
                     debugPrintln("brewSwitchTriggerCase 30: Brew Trigger LOW");
@@ -163,6 +163,7 @@ void checkbrewswitch() {
 void backflush() {
     if (backflushState != kBackflushWaitBrewswitchOn && backflushOn == 0) {
         backflushState = kBackflushWaitBrewswitchOff;  // Force reset in case backflushOn is reset during backflush!
+        debugPrintln("Backflush: Abort, disabled via Webinterface");
     }
     else if (offlineMode == 1 || brewCounter > kBrewIdle || maxflushCycles <= 0 || backflushOn == 0) {
         return;
@@ -193,7 +194,7 @@ void backflush() {
             break;
 
         case kBackflushFillingStart:
-            debugPrintln("Backflush: Portafilter filling...");
+            debugPrintf("Backflush (%i/%i): Portafilter filling...\n", flushCycles + 1, maxflushCycles);
             digitalWrite(PIN_VALVE, relayOn);
             digitalWrite(PIN_PUMP, relayOn);
             backflushState = kBackflushFilling;


### PR DESCRIPTION
Bugfix for Backflush not stopping when having Brew-switch configured as trigger:
Fixes behaviour for brewtrigger.
Adds one debug message for website-abort and extends debug message for backflush to include the backflush counter.

Bug:
- Configure brew switch as trigger
- Switch on Backflush via Webinterface
- Start Backflush with Brew-Trigger
- Backflush runs & finishes, stops at "press brewswitch to stop", even though mechanical brew trigger is off
Effect:
- When switching off Backflush via Webinterface, Display jumps between "normal Display" and "Backflush Display"

Desired outcome:
- Backflush jumps back to "press brew to start" once backflush-cycle is complete
