### PR TITLE
always store scalecalibration

### DIFF
--- a/src/storage.h
+++ b/src/storage.h
@@ -88,11 +88,7 @@ typedef struct __attribute__((packed)) {
     uint8_t freeToUse6[21];
     uint8_t pidBdOn;
     double pidKpBd;
-    #if SCALE_TYPE == 1
-    float freeToUse7;
-    #else
     float scale2Calibration;
-    #endif
     double pidTnBd;
     uint8_t freeToUse8[2];
     double pidTvBd;
@@ -333,12 +329,10 @@ static inline int32_t getItemAddr(sto_item_id_t itemId, uint16_t* maxItemSize = 
             size = STRUCT_MEMBER_SIZE(sto_data_t,scaleCalibration);
             break;
 
-        #if SCALE_TYPE != 1
         case STO_ITEM_SCALE2_CALIBRATION_FACTOR:
             addr = offsetof(sto_data_t,scale2Calibration );
             size = STRUCT_MEMBER_SIZE(sto_data_t,scale2Calibration);
             break;
-        #endif
 
         case STO_ITEM_SCALE_KNOWN_WEIGHT:
             addr = offsetof(sto_data_t,scaleKnownWeight );


### PR DESCRIPTION
always store calibration value, even only one hx711 is used.
otherwise storage gets messy