### PR TITLE
make sure the shot timer also shows when still in kAtSetpoint

### DIFF
--- a/src/display/displayCommon.h
+++ b/src/display/displayCommon.h
@@ -238,11 +238,10 @@ void displayLogo(String displaymessagetext, String displaymessagetext2) {
  * @brief display shot timer
  */
 void displayShottimer(void) {
-    if ((machineState == kBrew || brewSwitchState == kBrewSwitchFlushOff) && FEATURE_SHOTTIMER == 1 && SHOTTIMER_TYPE == 1) {
+    if ((machineState == kBrew || brewSwitchState == kBrewSwitchFlushOff) && SHOTTIMER_TYPE == 1) {
         u8g2.clearBuffer();
 
         if (brewSwitchState != kBrewSwitchFlushOff) {
-            // temp icon
             u8g2.drawXBMP(-1, 11, Brew_Cup_Logo_width, Brew_Cup_Logo_height, Brew_Cup_Logo);
         } 
         else {
@@ -256,10 +255,10 @@ void displayShottimer(void) {
     }
 
     /* if the totalBrewTime is reached automatically,
-    * nothing should be done, otherwise wrong time is displayed
-    * because the switch is pressed later than totalBrewTime
-    */
-    if (((machineState == kShotTimerAfterBrew && brewSwitchState != kBrewSwitchFlushOff) && FEATURE_SHOTTIMER == 1 && SHOTTIMER_TYPE == 1)) {
+     * nothing should be done, otherwise wrong time is displayed
+     * because the switch is pressed later than totalBrewTime
+     */
+    if ((machineState == kShotTimerAfterBrew && brewSwitchState != kBrewSwitchFlushOff) && SHOTTIMER_TYPE == 1) {
         u8g2.clearBuffer();
         u8g2.drawXBMP(-1, 11, Brew_Cup_Logo_width, Brew_Cup_Logo_height, Brew_Cup_Logo);
 
@@ -270,7 +269,7 @@ void displayShottimer(void) {
     }
 
     #if (ONLYPIDSCALE == 1 || BREWMODE == 2)
-        if ((machineState == kBrew) && FEATURE_SHOTTIMER == 1 && SHOTTIMER_TYPE == 2) {
+        if ((machineState == kBrew) && SHOTTIMER_TYPE == 2) {
             u8g2.clearBuffer();
 
             // temp icon
@@ -287,7 +286,7 @@ void displayShottimer(void) {
             u8g2.sendBuffer();
         }
 
-        if (((machineState == kShotTimerAfterBrew) && FEATURE_SHOTTIMER == 1 && SHOTTIMER_TYPE == 2)) {
+        if (((machineState == kShotTimerAfterBrew) && SHOTTIMER_TYPE == 2)) {
             u8g2.clearBuffer();
             u8g2.drawXBMP(-1, 11, Brew_Cup_Logo_width, Brew_Cup_Logo_height, Brew_Cup_Logo);
             u8g2.setFont(u8g2_font_profont22_tf);
@@ -302,14 +301,13 @@ void displayShottimer(void) {
             u8g2.sendBuffer();
         }
     #endif  
-
 }
 
 
 /**
  * @brief display heating logo
  */
-void Displaymachinestate() {
+void displayMachineState() {
     if (FEATURE_HEATINGLOGO > 0 && (machineState == kInit || machineState == kColdStart) && brewSwitchState != kBrewSwitchFlushOff) {
         // For status info
         u8g2.clearBuffer();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -994,6 +994,8 @@ void handleMachineState() {
 
         // Current temperature is just below the setpoint
         case kAtSetpoint:
+            brewDetection();
+
             // when temperature has reached BrewSetpoint properly, switch to kPidNormal
             if (temperature >= brewSetpoint) {
                 machineState = kPidNormal;
@@ -2375,7 +2377,7 @@ void looppid() {
     if (currentMillisDisplay - previousMillisDisplay >= intervalDisplay) {
         previousMillisDisplay = currentMillisDisplay;
     #if DISPLAYTEMPLATE < 20  // not using vertical template
-        Displaymachinestate();
+        displayMachineState();
     #endif
         printScreen();  // refresh display
     }


### PR DESCRIPTION
The brew detection got removed recently from the kAtSetpoint state which is 1° below the setpoint but it seems it should also be run there. In this state, the heating logo is already disabled so the shot timer should also work as in kBrew. The display looks the same in both cases so this was a bit confusing.