### PR TITLE
Adressable LEDs (like WS2811) in HAL

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -24,6 +24,7 @@ lib_deps =
     git+https://github.com/esphome/AsyncTCP#dc64fed
     git+https://github.com/esphome/ESPAsyncWebServer#f2a65ff
     git+https://github.com/tzapu/WiFiManager#71937d1
+    fastled/FastLED @ 3.6.0
 extra_scripts = pre:auto_firmware_version.py
 
 [env:esp32_usb]

--- a/src/brewHandler.h
+++ b/src/brewHandler.h
@@ -125,6 +125,8 @@ void checkbrewswitch() {
                 break;
 
             case kBrewSwitchFlushOff:
+                // Set white LED on, keep on even after manual brew and fade out
+                brewLEDon = BREW_FINISHED_LEDON_DURATION;
                 // Brew switch got released - stop flushing
                 if (currBrewSwitchStateMomentary == LOW && currStateBrewSwitch == LOW) {
                     brewSwitchState = kBrewSwitchReset;
@@ -344,6 +346,12 @@ void brew() {
                     brewDetected = 0;  // rearm brewDetection
                     currBrewState = kBrewIdle;
                     timeBrewed = 0;
+
+                    //LED illuminates coffee for BREW_FINISHED_LEDON_DURATION duration
+                    if (brewLEDon==0) 
+                    {
+                        brewLEDon = BREW_FINISHED_LEDON_DURATION;
+                    }
                 }
 
                 break;

--- a/src/hardware/LED.h
+++ b/src/hardware/LED.h
@@ -15,16 +15,18 @@ class LED {
          * @enum Type
          * @brief Type of LED
          * @details Supported types are standard LEDs which are directly connected to a GPIO pin and addressable 
-         *          WS2812 LEDs (NeoPixel) connected to the Status LED pin
+         *          WS2811, WS2812 (NeoPixel) LEDs connected to the Status LED pin
          */
         enum Type {
             STANDARD,
-            WS2812
+            WS2811,
+            WS2812,
+            WS2812B
         };
 
         virtual void turnOn() = 0;
         virtual void turnOff() = 0;
-        virtual void setColor(int red, int green, int blue) = 0;
+        virtual void setColor(int hue, int saturation, int value) = 0;
         virtual void setBrightness(int value) = 0;
         virtual ~LED() {}
 };

--- a/src/hardware/RGBLEDstrip.cpp
+++ b/src/hardware/RGBLEDstrip.cpp
@@ -1,0 +1,105 @@
+/**
+ * @file RGBLEDstrip.cpp
+ * 
+ * @brief A strip with adressable LEDs connected to a GPIO pin
+ */
+
+#include "RGBLEDstrip.h"
+#include "chipsets.h"
+
+RGBLEDstrip::RGBLEDstrip(int numLEDs, Type type) 
+    : ledType(type),
+      numLEDs(numLEDs), 
+      numAssignedLEDs(0) {
+
+    leds = new CRGB[numLEDs];
+
+    switch(type) {
+        case LED::WS2811: 
+            FastLED.addLeds<::WS2811, PIN_STATUSLED>(leds, numLEDs);  
+            break;
+
+        case LED::WS2812: 
+            FastLED.addLeds<::WS2812, PIN_STATUSLED>(leds, numLEDs);             
+            break;
+
+        case LED::WS2812B: 
+            FastLED.addLeds<::WS2812B, PIN_STATUSLED>(leds, numLEDs);
+            break;
+    }
+
+    turnOff();
+}
+
+RGBLEDstrip::~RGBLEDstrip() {
+    delete[] leds;
+}
+
+void RGBLEDstrip::turnOn() {
+    setBrightness(255); 
+}
+
+void RGBLEDstrip::turnOff() {
+    setBrightness(0); 
+}
+
+void RGBLEDstrip::setColor(int hue, int saturation, int value) {
+    setLEDRangeColor(0, numLEDs-1, hue, saturation, value);
+}
+
+void RGBLEDstrip::setBrightness(int value) {
+    setColor(0, 0, value);
+}
+
+void RGBLEDstrip::setLEDindexColor(int index, int hue, int saturation, int value) {
+    setLEDRangeColor(index, index + 1, hue, saturation, value);
+}
+
+void RGBLEDstrip::prepareLEDRangeColor(int start, int endPlusOne, int hue, int saturation, int value) {
+    if(start < 0 || endPlusOne > numLEDs) 
+        return; 
+    
+    for(int i = start; i < endPlusOne; i++) { 
+        leds[i].setHSV(hue, saturation, value);
+    };    
+}
+
+void RGBLEDstrip::setLEDRangeColor(int start, int endPlusOne, int hue, int saturation, int value) {
+    prepareLEDRangeColor(start, endPlusOne, hue, saturation, value);
+    FastLED.show();
+}
+
+void RGBLEDstrip::setLEDRangeRainbow(int start, int endPlusOne, int initialHue, int deltaHue) {
+    if(start < 0 || endPlusOne > numLEDs) return; 
+    CHSV hsv;
+    hsv.hue = initialHue;
+    hsv.val = 255;
+    hsv.sat = 240;
+    for( int i = 0; i < endPlusOne; ++i) {
+        leds[i] = hsv;
+        hsv.hue += deltaHue;
+    }
+    FastLED.show();
+}
+
+void RGBLEDstrip::setLEDRangeColorTwoValues(int start, int endPlusOne, int hue, int saturation, int value1, int value2) {
+    if(start < 0 || endPlusOne > numLEDs) return; 
+    int numFirstHalf = ( endPlusOne - start ) / 2;
+    int idSecondHalf = start + numFirstHalf;
+    prepareLEDRangeColor(start, idSecondHalf, hue, saturation, value1);
+    prepareLEDRangeColor(idSecondHalf, endPlusOne, hue, saturation, value2);
+    FastLED.show();
+}
+
+int RGBLEDstrip::assignLED() {
+    numAssignedLEDs++;
+    return numAssignedLEDs-1;
+}
+
+int RGBLEDstrip::getNumAssignedLEDs() {
+    return numAssignedLEDs;
+}
+
+int RGBLEDstrip::getNumLEDs() {
+    return numLEDs;
+}

--- a/src/hardware/RGBLEDstrip.h
+++ b/src/hardware/RGBLEDstrip.h
@@ -1,0 +1,38 @@
+/**
+ * @file RGBLEDstrip.h
+ * 
+ * @brief A strip with adressable LEDs connected to a GPIO pin
+ */
+
+#pragma once
+
+#include "LED.h"
+#include "pinmapping.h"
+#include <FastLED.h>
+
+class RGBLEDstrip  : public LED {
+public:
+    RGBLEDstrip(int numLEDs, Type type); 
+    virtual ~RGBLEDstrip();
+
+    void turnOn() override;
+    void turnOff() override;
+    void setColor(int hue, int saturation, int value) override; 
+    void setBrightness(int value) override;
+
+    void setLEDindexColor(int index, int hue, int saturation, int value); // Single LED with HSV
+    void setLEDRangeColor(int start, int end, int hue, int saturation, int value); // Color for a group of LEDs
+    void prepareLEDRangeColor(int start, int end, int hue, int saturation, int value);
+    void setLEDRangeRainbow(int start, int end, int initialHue, int deltaHue); // Fill range with rainbow colors
+    void setLEDRangeColorTwoValues(int start, int end, int hue, int saturation, int value1, int value2);
+
+    int assignLED(); // return lowest not assigned LED and count number of assigned LEDs one up
+    int getNumAssignedLEDs(); // return lowest not assigned LED
+    int getNumLEDs(); // return total number of LEDs in strip
+
+private:
+    CRGB* leds; // Pointer to the array of LEDs
+    int numLEDs; // Number of LEDs in the strip
+    int numAssignedLEDs; // Number of assigned LEDs (not available for context LED settings)
+    Type ledType;
+};

--- a/src/hardware/RgbMultipleLED.cpp
+++ b/src/hardware/RgbMultipleLED.cpp
@@ -1,0 +1,41 @@
+/**
+ * @file RgbMultipleLED.cpp
+ * 
+ * @brief Subgroup of adressable LEDs on the strip (all LEDs which are not the status or brew LED).
+ * 
+ * @param ledStrip The constructor saves the reference to the RGBLED object.
+ */
+
+#include "RgbMultipleLED.h"
+
+RgbMultipleLED::RgbMultipleLED(RGBLEDstrip& ledStrip) 
+    : ledStrip(ledStrip),
+      startLEDid (0),
+      numLEDs (0) {
+    startLEDid = ledStrip.getNumAssignedLEDs(); 
+    numLEDs = ledStrip.getNumLEDs(); 
+}
+
+void RgbMultipleLED::turnOn() {
+    setBrightness(255); 
+}
+
+void RgbMultipleLED::turnOff() {
+    setBrightness(0); 
+}
+
+void RgbMultipleLED::setBrightness(int value) {
+    setColor(0, 0, value); 
+}
+
+void RgbMultipleLED::setColor(int hue, int saturation, int value) {
+    ledStrip.setLEDRangeColor(startLEDid, numLEDs, hue, saturation, value);
+}
+
+void RgbMultipleLED::setRainbow(int initialHue, int deltaHue) {
+    ledStrip.setLEDRangeRainbow(startLEDid, numLEDs, initialHue, deltaHue);
+}
+
+void RgbMultipleLED::setColorTwoValues(int hue, int saturation, int value1, int value2) {
+    ledStrip.setLEDRangeColorTwoValues(startLEDid, numLEDs, hue, saturation, value1, value2);
+}

--- a/src/hardware/RgbMultipleLED.h
+++ b/src/hardware/RgbMultipleLED.h
@@ -1,0 +1,26 @@
+/**
+ * @file RgbMultipleLED.h
+ * 
+ * @brief Subgroup of adressable LEDs on the strip (all LEDs which are not the status or brew LED).
+ */
+
+#pragma once
+
+#include "RGBLEDstrip.h"
+
+class RgbMultipleLED : public LED {
+public:
+    RgbMultipleLED(RGBLEDstrip& ledStrip);
+
+    void turnOn() override;
+    void turnOff() override;
+    void setColor(int hue, int saturation, int value) override;
+    void setBrightness(int value) override;
+    void setRainbow(int initialHue, int deltaHu);
+    void setColorTwoValues(int hue, int saturation, int value1, int value2);
+
+private:
+    RGBLEDstrip& ledStrip; // Reference to the RGBLED object.
+    int startLEDid; 
+    int numLEDs;
+};

--- a/src/hardware/RgbSingleLED.cpp
+++ b/src/hardware/RgbSingleLED.cpp
@@ -1,0 +1,33 @@
+/**
+ * @file RgbSingleLED.cpp
+ * 
+ * @brief Single adressable LED, like status or brew LED
+ * 
+ * @param ledStrip The constructor saves the reference to the RGBLED object.
+ */
+
+#include "RgbSingleLED.h"
+
+RgbSingleLED::RgbSingleLED(RGBLEDstrip& ledStrip) 
+    : ledStrip(ledStrip),
+      LEDid (0) {
+    LEDid = ledStrip.assignLED(); 
+}
+
+void RgbSingleLED::turnOn() {
+    // Set a single LED to 100% white.
+    setBrightness(255); 
+}
+
+void RgbSingleLED::turnOff() {
+    // Turn off a single LED to indicate "off" status.
+    setBrightness(0); 
+}
+
+void RgbSingleLED::setColor(int hue, int saturation, int value) {
+    ledStrip.setLEDindexColor(LEDid, hue, saturation, value); 
+}
+
+void RgbSingleLED::setBrightness(int value) {
+    setColor(0, 0, value); 
+}

--- a/src/hardware/RgbSingleLED.h
+++ b/src/hardware/RgbSingleLED.h
@@ -1,0 +1,24 @@
+/**
+ * @file RgbSingleLED.h
+ * 
+ * @brief Single adressable LED, like status or brew LED
+ */
+
+#pragma once
+
+#include "RGBLEDstrip.h"
+
+class RgbSingleLED : public LED {
+public:
+    // Constructor: Accepts a reference to an existing RGBLED object.
+    RgbSingleLED(RGBLEDstrip& ledStrip);
+
+    void turnOn() override;
+    void turnOff() override;
+    void setColor(int hue, int saturation, int value) override;
+    void setBrightness(int value) override;
+
+private:
+    RGBLEDstrip& ledStrip; // Reference to the RGBLED object.
+    int LEDid; 
+};

--- a/src/hardware/StandardLED.cpp
+++ b/src/hardware/StandardLED.cpp
@@ -17,7 +17,7 @@ void StandardLED::turnOff() {
     gpio.write(LOW);
 }
 
-void StandardLED::setColor(int red, int green, int blue) {
+void StandardLED::setColor(int hue, int saturation, int value) {
     // Not applicable for standard LEDs
 }
 

--- a/src/hardware/StandardLED.h
+++ b/src/hardware/StandardLED.h
@@ -16,7 +16,7 @@ class StandardLED : public LED {
 
         void turnOn() override;
         void turnOff() override;
-        void setColor(int red, int green, int blue);
+        void setColor(int hue, int saturation, int value);
         void setBrightness(int value);
 
     private:

--- a/src/hardware/Switch.h
+++ b/src/hardware/Switch.h
@@ -1,5 +1,5 @@
 /**
- * @file LED.h
+ * @file Switch.h
  * 
  * @brief Interface that switches have to implement
  */

--- a/src/hardware/pinmapping.h
+++ b/src/hardware/pinmapping.h
@@ -39,7 +39,7 @@
 #define PIN_HEATER 2
 
 // LEDs
-#define PIN_STATUSLED 26
+#define PIN_STATUSLED 26 // also default pin for RGB leds
 #define PIN_BREWLED 19
 #define PIN_STEAMLED 1
 

--- a/src/userConfig_sample.h
+++ b/src/userConfig_sample.h
@@ -67,7 +67,10 @@ enum MACHINE {
 #define PUMP_VALVE_SSR_TYPE Relay::HIGH_TRIGGER  // HIGH_TRIGGER = relay switches when input is HIGH, vice versa for LOW_TRIGGER
 #define FEATURE_STATUS_LED 0                     // Blink status LED when temp is in range, 0 = deactivated, 1 = activated
 #define FEATURE_BREW_LED 0                       // Turn on brew LED when brew is started, 0 = deactivated, 1 = activated
-#define LED_TYPE LED::STANDARD                   // STANDARD_LED for an LED connected to a GPIO pin, WS2812 for adressable LEDs
+#define FEATURE_CONTEXT_LED 0                    // Context: BrewReady-white, Error-red, TempOK-green, Startup-Rainbow, Steam-Yellow, Backflush-white, 0 = deactivated, 1 = activated
+#define CONTEXT_LED_PIDON_BRIGHTNESS 40          // Brightness from 0-255 for the cup illumination when machine is on
+#define LED_TYPE LED::STANDARD                   // STANDARD for an LED connected to a GPIO pin, WS2811, WS2812, WS2812B for adressable LEDs
+#define RGB_LED_NUM 4                            // Number of adressable LEDs attached. Not considered if FEATURE_STATUS_LED above is zero
 #define FEATURE_WATER_SENS 0                     // 0 = deactivated, 1 = activated
 #define WATER_SENS_TYPE 0                        // 0 = water sensor XKC-Y25-NPN connected, 1 = XKC-Y25-PNP connected
 #define FEATURE_PRESSURESENSOR 0                 // 0 = deactivated, 1 = activated


### PR DESCRIPTION
Added adressable LEDs for the HAL.
Status / brew LEDs are automatically assigned first, remainder is assigned to context-LEDs.
All based on LED class: One RGBLEDstrip class provides access to WS2811/WS2812/...  Additional classes for single-LEDs and multiple-LEDs. Cleanup of LED code in main.cpp

Detail:
Added FastLED library, and LED handling for Neopixels with e.g. WS2811 chip.
LoopLED will be called every 80ms for relatively smooth LED animations.
Number of LEDs and chip type are configurable.
Library is using Hardware features of ESP32 to avoid interrup conflicts

PID-on (not standby) -> low brightness white
Perfect temp -> dark green
Brew/Steam/Backflush -> white
Initialize, cold start Heat up -> Colors
Error message -> Red heartbeat (Water empty, sensor error, etc)
Steam-heat-up -> dark yellow