### PR TITLE
Remove ONLYPID and ONLYPIDSCALE

### DIFF
--- a/src/brewHandler.h
+++ b/src/brewHandler.h
@@ -230,124 +230,122 @@ void backflush() {
     }
 }
 
-#if (BREWMODE == 1)  // normal brew mode (based on time)
+#if (BREWMODE == 1)  
 /**
- * @brief PreInfusion, Brew Normal
+ * @brief Time base brew mode
  */
 void brew() {
-    if (OnlyPID == 0) {
-        unsigned long currentMillisTemp = millis();
-        checkbrewswitch();
+    unsigned long currentMillisTemp = millis();
+    checkbrewswitch();
 
-        if (currStateBrewSwitch == LOW && currBrewState > kBrewIdle) {
-            // abort function for state machine from every state
-            LOG(INFO, "Brew stopped manually");
-            currBrewState = kWaitBrewOff;
-        }
+    if (currStateBrewSwitch == LOW && currBrewState > kBrewIdle) {
+        // abort function for state machine from every state
+        LOG(INFO, "Brew stopped manually");
+        currBrewState = kWaitBrewOff;
+    }
 
-        if (currBrewState > kBrewIdle && currBrewState < kWaitBrewOff || brewSwitchState == kBrewSwitchFlushOff) {
-            timeBrewed = currentMillisTemp - startingTime;
-        }
+    if (currBrewState > kBrewIdle && currBrewState < kWaitBrewOff || brewSwitchState == kBrewSwitchFlushOff) {
+        timeBrewed = currentMillisTemp - startingTime;
+    }
 
-        if (currStateBrewSwitch == LOW && movingAverageInitialized) {
-            // check if brewswitch was turned off at least once, last time,
-            brewSwitchWasOff = true;
-        }
+    if (currStateBrewSwitch == LOW && movingAverageInitialized) {
+        // check if brewswitch was turned off at least once, last time,
+        brewSwitchWasOff = true;
+    }
 
-        totalBrewTime = (preinfusion * 1000) + (preinfusionPause * 1000) +
-            (brewTime * 1000);  // running every cycle, in case changes are done during brew
+    totalBrewTime = (preinfusion * 1000) + (preinfusionPause * 1000) +
+        (brewTime * 1000);  // running every cycle, in case changes are done during brew
 
-        // state machine for brew
-        switch (currBrewState) {
-            case kBrewIdle: // waiting step for brew switch turning on
-                if (currStateBrewSwitch == HIGH && backflushState == 10 && backflushOn == 0 && brewSwitchWasOff && machineState != kWaterEmpty) {
-                    startingTime = millis();
+    // state machine for brew
+    switch (currBrewState) {
+        case kBrewIdle: // waiting step for brew switch turning on
+            if (currStateBrewSwitch == HIGH && backflushState == 10 && backflushOn == 0 && brewSwitchWasOff && machineState != kWaterEmpty) {
+                startingTime = millis();
 
-                    if (preinfusionPause == 0 || preinfusion == 0) {
-                        currBrewState = kBrewRunning;
-                    }
-                    else {
-                        currBrewState = kPreinfusion;
-                    }
-
-                    coldstart = false;  // force reset coldstart if shot is pulled
-                }
-                else {
-                    backflush();
-                }
-
-                break;
-
-            case kPreinfusion:  // preinfusioon
-                LOG(INFO, "Preinfusion");
-                valveRelay.on();
-                pumpRelay.on();
-                currBrewState = kWaitPreinfusion;
-
-                break;
-
-            case kWaitPreinfusion:  // waiting time preinfusion
-                if (timeBrewed > (preinfusion * 1000)) {
-                    currBrewState = kPreinfusionPause;
-                }
-
-                break;
-
-            case kPreinfusionPause:  // preinfusion pause
-                LOG(INFO, "Preinfusion pause");
-                valveRelay.on();
-                pumpRelay.off();
-                currBrewState = kWaitPreinfusionPause;
-
-                break;
-
-            case kWaitPreinfusionPause:  // waiting time preinfusion pause
-                if (timeBrewed > ((preinfusion * 1000) + (preinfusionPause * 1000))) {
+                if (preinfusionPause == 0 || preinfusion == 0) {
                     currBrewState = kBrewRunning;
                 }
-
-                break;
-
-            case kBrewRunning:  // brew running
-                LOG(INFO, "Brew started");
-                valveRelay.on();
-                pumpRelay.on();
-                currBrewState = kWaitBrew;
-
-                break;
-
-            case kWaitBrew:  // waiting time brew
-                lastBrewTime = timeBrewed;
-
-                if (timeBrewed > totalBrewTime) {
-                    currBrewState = kBrewFinished;
+                else {
+                    currBrewState = kPreinfusion;
                 }
 
-                break;
+                coldstart = false;  // force reset coldstart if shot is pulled
+            }
+            else {
+                backflush();
+            }
 
-            case kBrewFinished:  // brew finished
-                LOG(INFO, "Brew stopped");
+            break;
+
+        case kPreinfusion:  // preinfusioon
+            LOG(INFO, "Preinfusion");
+            valveRelay.on();
+            pumpRelay.on();
+            currBrewState = kWaitPreinfusion;
+
+            break;
+
+        case kWaitPreinfusion:  // waiting time preinfusion
+            if (timeBrewed > (preinfusion * 1000)) {
+                currBrewState = kPreinfusionPause;
+            }
+
+            break;
+
+        case kPreinfusionPause:  // preinfusion pause
+            LOG(INFO, "Preinfusion pause");
+            valveRelay.on();
+            pumpRelay.off();
+            currBrewState = kWaitPreinfusionPause;
+
+            break;
+
+        case kWaitPreinfusionPause:  // waiting time preinfusion pause
+            if (timeBrewed > ((preinfusion * 1000) + (preinfusionPause * 1000))) {
+                currBrewState = kBrewRunning;
+            }
+
+            break;
+
+        case kBrewRunning:  // brew running
+            LOG(INFO, "Brew started");
+            valveRelay.on();
+            pumpRelay.on();
+            currBrewState = kWaitBrew;
+
+            break;
+
+        case kWaitBrew:  // waiting time brew
+            lastBrewTime = timeBrewed;
+
+            if (timeBrewed > totalBrewTime) {
+                currBrewState = kBrewFinished;
+            }
+
+            break;
+
+        case kBrewFinished:  // brew finished
+            LOG(INFO, "Brew stopped");
+            valveRelay.off();
+            pumpRelay.off();
+            currBrewState = kWaitBrewOff;
+            timeBrewed = 0;
+
+            break;
+
+        case kWaitBrewOff:  // waiting for brewswitch off position
+            if (currStateBrewSwitch == LOW) {
                 valveRelay.off();
                 pumpRelay.off();
-                currBrewState = kWaitBrewOff;
+
+                // disarmed button
+                currentMillisTemp = 0;
+                brewDetected = 0;  // rearm brewDetection
+                currBrewState = kBrewIdle;
                 timeBrewed = 0;
+            }
 
-                break;
-
-            case kWaitBrewOff:  // waiting for brewswitch off position
-                if (currStateBrewSwitch == LOW) {
-                    valveRelay.off();
-                    pumpRelay.off();
-
-                    // disarmed button
-                    currentMillisTemp = 0;
-                    brewDetected = 0;  // rearm brewDetection
-                    currBrewState = kBrewIdle;
-                    timeBrewed = 0;
-                }
-
-                break;
-        }
+            break;
     }
 }
 #endif
@@ -357,116 +355,114 @@ void brew() {
  * @brief Weight based brew mode
  */
 void brew() {
-    if (OnlyPID == 0) {
-        checkbrewswitch();
-        unsigned long currentMillisTemp = millis();
+    checkbrewswitch();
+    unsigned long currentMillisTemp = millis();
 
-        if (currStateBrewSwitch == LOW && currBrewState > kBrewIdle) {
-            // abort function for state machine from every state
-            currBrewState = kWaitBrewOff;
-        }
+    if (currStateBrewSwitch == LOW && currBrewState > kBrewIdle) {
+        // abort function for state machine from every state
+        currBrewState = kWaitBrewOff;
+    }
 
-        if (currBrewState > kBrewIdle && currBrewState < kWaitBrewOff) {
-            timeBrewed = currentMillisTemp - startingTime;
-            weightBrew = weight - weightPreBrew;
-        }
+    if (currBrewState > kBrewIdle && currBrewState < kWaitBrewOff) {
+        timeBrewed = currentMillisTemp - startingTime;
+        weightBrew = weight - weightPreBrew;
+    }
 
-        if (currStateBrewSwitch == LOW && movingAverageInitialized) {
-            // check if brewswitch was turned off at least once, last time,
-            brewSwitchWasOff = true;
-        }
+    if (currStateBrewSwitch == LOW && movingAverageInitialized) {
+        // check if brewswitch was turned off at least once, last time,
+        brewSwitchWasOff = true;
+    }
 
-        totalBrewTime = ((preinfusion * 1000) + (preinfusionPause * 1000) +
-            (brewTime * 1000));  // running every cycle, in case changes are done during brew
+    totalBrewTime = ((preinfusion * 1000) + (preinfusionPause * 1000) +
+        (brewTime * 1000));  // running every cycle, in case changes are done during brew
 
-        // state machine for brew
-        switch (currBrewState) {
-            case 10:  // waiting step for brew switch turning on
-                if (currStateBrewSwitch == HIGH && backflushState == 10 && backflushOn == 0 && brewSwitchWasOff) {
-                    startingTime = millis();
-                    currBrewState = kPreinfusion;
+    // state machine for brew
+    switch (currBrewState) {
+        case 10:  // waiting step for brew switch turning on
+            if (currStateBrewSwitch == HIGH && backflushState == 10 && backflushOn == 0 && brewSwitchWasOff) {
+                startingTime = millis();
+                currBrewState = kPreinfusion;
 
-                    if (preinfusionPause == 0 || preinfusion == 0) {
-                        currBrewState = kBrewRunning;
-                    }
-
-                    coldstart = false;  // force reset coldstart if shot is pulled
-                    weightPreBrew = weight;
-                } else {
-                    backflush();
-                }
-
-                break;
-
-            case 20:  // preinfusioon
-                LOG(INFO, "Preinfusion");
-                valveRelay.on();
-                pumpRelay.on();
-                currBrewState = kWaitPreinfusion;
-
-                break;
-
-            case 21:  // waiting time preinfusion
-                if (timeBrewed > (preinfusion * 1000)) {
-                    currBrewState = kPreinfusionPause;
-                }
-
-                break;
-
-            case 30:  // preinfusion pause
-                LOG(INFO, "preinfusion pause");
-                valveRelay.on();
-                pumpRelay.off();
-                currBrewState = kWaitPreinfusionPause;
-
-                break;
-
-            case 31:  // waiting time preinfusion pause
-                if (timeBrewed > ((preinfusion * 1000) + (preinfusionPause * 1000))) {
+                if (preinfusionPause == 0 || preinfusion == 0) {
                     currBrewState = kBrewRunning;
                 }
 
-                break;
+                coldstart = false;  // force reset coldstart if shot is pulled
+                weightPreBrew = weight;
+            } else {
+                backflush();
+            }
 
-            case 40:  // brew running
-                LOG(INFO, "Brew started");
-                valveRelay.on();
-                pumpRelay.on();
-                currBrewState = kWaitBrew;
+            break;
 
-                break;
+        case 20:  // preinfusioon
+            LOG(INFO, "Preinfusion");
+            valveRelay.on();
+            pumpRelay.on();
+            currBrewState = kWaitPreinfusion;
 
-            case 41:  // waiting time brew
-                if (weightBrew > (weightSetpoint - scaleDelayValue)) {
-                    currBrewState = kBrewFinished;
-                }
+            break;
 
-                break;
+        case 21:  // waiting time preinfusion
+            if (timeBrewed > (preinfusion * 1000)) {
+                currBrewState = kPreinfusionPause;
+            }
 
-            case 42:  // brew finished
-                LOG(INFO, "Brew stopped");
+            break;
+
+        case 30:  // preinfusion pause
+            LOG(INFO, "preinfusion pause");
+            valveRelay.on();
+            pumpRelay.off();
+            currBrewState = kWaitPreinfusionPause;
+
+            break;
+
+        case 31:  // waiting time preinfusion pause
+            if (timeBrewed > ((preinfusion * 1000) + (preinfusionPause * 1000))) {
+                currBrewState = kBrewRunning;
+            }
+
+            break;
+
+        case 40:  // brew running
+            LOG(INFO, "Brew started");
+            valveRelay.on();
+            pumpRelay.on();
+            currBrewState = kWaitBrew;
+
+            break;
+
+        case 41:  // waiting time brew
+            if (weightBrew > (weightSetpoint - scaleDelayValue)) {
+                currBrewState = kBrewFinished;
+            }
+
+            break;
+
+        case 42:  // brew finished
+            LOG(INFO, "Brew stopped");
+            valveRelay.off();
+            pumpRelay.off();
+            currBrewState = kWaitBrewOff;
+
+            break;
+
+        case 43:  // waiting for brewswitch off position
+            if (brewSwitch == LOW) {
                 valveRelay.off();
                 pumpRelay.off();
-                currBrewState = kWaitBrewOff;
 
-                break;
+                // disarmed button
+                currentMillisTemp = 0;
+                timeBrewed = 0;
+                brewDetected = 0;  // rearm brewDetection
+                currBrewState = kBrewIdle;
+            }
 
-            case 43:  // waiting for brewswitch off position
-                if (brewSwitch == LOW) {
-                    valveRelay.off();
-                    pumpRelay.off();
+            weightBrew = weight - weightPreBrew;  // always calculate weight to show on display
 
-                    // disarmed button
-                    currentMillisTemp = 0;
-                    timeBrewed = 0;
-                    brewDetected = 0;  // rearm brewDetection
-                    currBrewState = kBrewIdle;
-                }
-
-                weightBrew = weight - weightPreBrew;  // always calculate weight to show on display
-
-                break;
-        }
+            break;
     }
 }
 #endif

--- a/src/brewHandler.h
+++ b/src/brewHandler.h
@@ -230,7 +230,7 @@ void backflush() {
     }
 }
 
-#if (BREWMODE == 1)  
+#if (BREWCONTROL_TYPE == 1)  
 /**
  * @brief Time base brew mode
  */
@@ -350,7 +350,7 @@ void brew() {
 }
 #endif
 
-#if (BREWMODE == 2)
+#if (BREWCONTROL_TYPE == 2)
 /**
  * @brief Weight based brew mode
  */

--- a/src/brewHandler.h
+++ b/src/brewHandler.h
@@ -54,7 +54,7 @@ unsigned long startingTime = 0;                     // start time of brew
 boolean brewPIDDisabled = false;                    // is PID disabled for delay after brew has started?
 
 // Shot timer with or without scale
-#if (ONLYPIDSCALE == 1 || BREWMODE == 2)
+#if FEATURE_SCALE == 1
     boolean scaleCalibrationOn = 0;
     boolean scaleTareOn = 0;
     int shottimerCounter = 10 ;

--- a/src/display/displayCommon.h
+++ b/src/display/displayCommon.h
@@ -272,7 +272,7 @@ void displayShottimer(void) {
         u8g2.sendBuffer();
     }
 
-    #if (ONLYPIDSCALE == 1 || BREWMODE == 2)
+    #if FEATURE_SCALE == 1
         if ((machineState == kBrew) && SHOTTIMER_TYPE == 2) {
             u8g2.clearBuffer();
 

--- a/src/display/displayRotateUpright.h
+++ b/src/display/displayRotateUpright.h
@@ -89,8 +89,8 @@ void displayEmergencyStop(void) {
  * @brief display shot timer
  */
 void displayShottimer(void) {
-    if (((timeBrewed > 0 && ONLYPID == 1) ||
-        (ONLYPID == 0 && currBrewState > kBrewIdle && currBrewState <= kBrewFinished))
+    if (((timeBrewed > 0 && BREWMODE == 0) ||
+        (BREWMODE > 0 && currBrewState > kBrewIdle && currBrewState <= kBrewFinished))
         && FEATURE_SHOTTIMER == 1 && SHOTTIMER_TYPE == 1)
     {
         u8g2.clearBuffer();

--- a/src/display/displayRotateUpright.h
+++ b/src/display/displayRotateUpright.h
@@ -89,8 +89,8 @@ void displayEmergencyStop(void) {
  * @brief display shot timer
  */
 void displayShottimer(void) {
-    if (((timeBrewed > 0 && BREWMODE == 0) ||
-        (BREWMODE > 0 && currBrewState > kBrewIdle && currBrewState <= kBrewFinished))
+    if (((timeBrewed > 0 && BREWCONTROL_TYPE == 0) ||
+        (BREWCONTROL_TYPE > 0 && currBrewState > kBrewIdle && currBrewState <= kBrewFinished))
         && FEATURE_SHOTTIMER == 1 && SHOTTIMER_TYPE == 1)
     {
         u8g2.clearBuffer();

--- a/src/display/displayTemplateMinimal.h
+++ b/src/display/displayTemplateMinimal.h
@@ -81,7 +81,7 @@ void printScreen() {
                 u8g2.print(timeBrewed / 1000, 0);
                 u8g2.print("/");
 
-                if (ONLYPID == 1) {
+                if (BREWMODE == 0) {
                     u8g2.print(brewtimesoftware, 0);
                 } 
                 else {

--- a/src/display/displayTemplateMinimal.h
+++ b/src/display/displayTemplateMinimal.h
@@ -81,7 +81,7 @@ void printScreen() {
                 u8g2.print(timeBrewed / 1000, 0);
                 u8g2.print("/");
 
-                if (BREWMODE == 0) {
+                if (BREWCONTROL_TYPE == 0) {
                     u8g2.print(brewtimesoftware, 0);
                 } 
                 else {

--- a/src/display/displayTemplateScale.h
+++ b/src/display/displayTemplateScale.h
@@ -69,7 +69,7 @@ void printScreen() {
         u8g2.print(timeBrewed / 1000, 0);
         u8g2.print("/");
 
-        if (ONLYPID == 1) {
+        if (BREWMODE == 0) {
             u8g2.print(brewtimesoftware, 0);
         }
         else {

--- a/src/display/displayTemplateScale.h
+++ b/src/display/displayTemplateScale.h
@@ -69,7 +69,7 @@ void printScreen() {
         u8g2.print(timeBrewed / 1000, 0);
         u8g2.print("/");
 
-        if (BREWMODE == 0) {
+        if (BREWCONTROL_TYPE == 0) {
             u8g2.print(brewtimesoftware, 0);
         }
         else {

--- a/src/display/displayTemplateStandard.h
+++ b/src/display/displayTemplateStandard.h
@@ -60,7 +60,7 @@ void printScreen()
             u8g2.print(timeBrewed / 1000, 0);
             u8g2.print("/");
 
-            if (BREWMODE == 0) {
+            if (BREWCONTROL_TYPE == 0) {
                 u8g2.print(brewtimesoftware, 0);
             }
             else {

--- a/src/display/displayTemplateStandard.h
+++ b/src/display/displayTemplateStandard.h
@@ -60,7 +60,7 @@ void printScreen()
             u8g2.print(timeBrewed / 1000, 0);
             u8g2.print("/");
 
-            if (ONLYPID == 1) {
+            if (BREWMODE == 0) {
                 u8g2.print(brewtimesoftware, 0);
             }
             else {

--- a/src/display/displayTemplateUpright.h
+++ b/src/display/displayTemplateUpright.h
@@ -99,7 +99,7 @@ void printScreen() {
             u8g2.print(timeBrewed / 1000, 0);
             u8g2.print("/");
 
-            if (BREWMODE == 0) {
+            if (BREWCONTROL_TYPE == 0) {
                 u8g2.print(brewtimesoftware, 0);// deaktivieren wenn Preinfusion ( // voransetzen )
             }
             else {

--- a/src/display/displayTemplateUpright.h
+++ b/src/display/displayTemplateUpright.h
@@ -99,7 +99,7 @@ void printScreen() {
             u8g2.print(timeBrewed / 1000, 0);
             u8g2.print("/");
 
-            if (ONLYPID == 1) {
+            if (BREWMODE == 0) {
                 u8g2.print(brewtimesoftware, 0);// deaktivieren wenn Preinfusion ( // voransetzen )
             }
             else {

--- a/src/embeddedWebserver.h
+++ b/src/embeddedWebserver.h
@@ -274,7 +274,7 @@ void serverSetup() {
         request->redirect("/");
     });
 
-#if (ONLYPIDSCALE == 1 || BREWMODE == 2)
+#if FEATURE_SCALE == 1
     server.on("/toggleTareScale", HTTP_POST, [](AsyncWebServerRequest *request) {
         int tare = flipUintValue(scaleTareOn);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -54,7 +54,7 @@ hw_timer_t *timer = NULL;
 #include <SPI.h>
 #endif
 
-#if (BREWMODE == 2 || ONLYPIDSCALE == 1)
+#if FEATURE_SCALE == 1
     #define HX711_ADC_config_h
     #define SAMPLES 32
     #define IGN_HIGH_SAMPLE 1
@@ -1770,7 +1770,7 @@ void setup() {
         .type = kDouble,
         .section = sTempSection,
         .position = 17,
-        .show = [] { return true && (ONLYPIDSCALE == 1 || BREWMODE == 2); },
+        .show = [] { return true && FEATURE_SCALE == 1; },
         .minValue = WEIGHTSETPOINT_MIN,
         .maxValue = WEIGHTSETPOINT_MAX,
         .ptr = (void *)&weightSetpoint
@@ -1942,7 +1942,7 @@ void setup() {
         .ptr = (void *)&standbyModeTime
     };
 
-#if (ONLYPIDSCALE == 1 || BREWMODE == 2)
+#if FEATURE_SCALE == 1
     editableVars["TARE_ON"] = {
         .displayName = F("Tare"),
         .hasHelpText = false,
@@ -2051,7 +2051,7 @@ void setup() {
         mqttVars["preinfusion"] = []{ return &editableVars.at("BREW_PREINFUSION"); };
     }
 
-    if (ONLYPIDSCALE == 1 || BREWMODE == 2) {
+    if (FEATURE_SCALE == 1) {
         mqttVars["weightSetpoint"] = []{ return &editableVars.at("SCALE_WEIGHTSETPOINT"); };
         mqttVars["scaleCalibration"] = []{ return &editableVars.at("SCALE_CALIBRATION"); };
         #if SCALE_TYPE == 0
@@ -2087,7 +2087,7 @@ void setup() {
         mqttSensors["pressure"] = []{ return inputPressureFilter; };
     #endif
 
-    #if (BREWMODE == 2 || ONLYPIDSCALE == 1)
+    #if FEATURE_SCALE == 1
         mqttSensors["currentWeight"] = []{ return weight; };
     #endif
 
@@ -2208,8 +2208,8 @@ void setup() {
 
     temperature -= brewTempOffset;
 
-    // Init Scale by BREWMODE 2 or SHOTTIMER 2
-    #if (BREWMODE == 2 || ONLYPIDSCALE == 1)
+    // Init Scale 
+    #if FEATURE_SCALE == 1
         initScale();
     #endif
 
@@ -2223,7 +2223,7 @@ void setup() {
     previousMillisOptocouplerReading = currentTime;
     lastMQTTConnectionAttempt = currentTime;
 
-    #if (BREWMODE == 2)
+    #if FEATURE_SCALE == 1
         previousMillisScale = currentTime;
     #endif
 
@@ -2334,7 +2334,7 @@ void looppid() {
         }
     }
 
-    #if (BREWMODE == 2 || ONLYPIDSCALE == 1)
+    #if FEATURE_SCALE == 1
         checkWeight();  // Check Weight Scale in the loop
     #endif
 
@@ -2369,7 +2369,7 @@ void looppid() {
 
     handleMachineState();
 
-    #if (ONLYPIDSCALE == 1)  // only by shottimer 2, scale
+    #if (FEATURE_SCALE == 1 && BREWMODE == 0)  // SHOTTIMER with scale
         shottimerscale();
     #endif
 
@@ -2566,14 +2566,14 @@ void setBackflush(int backflush) {
     backflushOn = backflush;
 }
 
-#if (ONLYPIDSCALE == 1 || BREWMODE == 2)
-void setScaleCalibration(int calibration) {
-    scaleCalibrationOn = calibration;
-}
+#if FEATURE_SCALE == 1
+    void setScaleCalibration(int calibration) {
+        scaleCalibrationOn = calibration;
+    }
 
-void setScaleTare(int tare) {
-    scaleTareOn = tare;
-}
+    void setScaleTare(int tare) {
+        scaleTareOn = tare;
+    }
 #endif
 
 void setSteamMode(int steamMode) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -110,7 +110,7 @@ int offlineMode = 0;
 const int brewDetectionMode = BREWDETECTION_TYPE;
 const int optocouplerType = OPTOCOUPLER_TYPE;
 const boolean ota = OTA;
-int BrewMode = BREWMODE;
+int brewControlType = BREWCONTROL_TYPE;
 
 // Display
 uint8_t oled_i2c = OLED_I2C;
@@ -946,8 +946,8 @@ void handleMachineState() {
                     break;
             }
 
-            if ((timeBrewed > 0 && BREWMODE == 0) ||  // timeBrewed without controlling brew
-                (BREWMODE > 0 && currBrewState > kBrewIdle && currBrewState <= kBrewFinished))
+            if ((timeBrewed > 0 && BREWCONTROL_TYPE == 0) ||  // timeBrewed without controlling brew
+                (BREWCONTROL_TYPE > 0 && currBrewState > kBrewIdle && currBrewState <= kBrewFinished))
             {
                 machineState = kBrew;
 
@@ -1001,8 +1001,8 @@ void handleMachineState() {
             }
 
             // is a brew running? (values are set in brewDetection() above)
-            if ((timeBrewed > 0 && BREWMODE == 0) ||
-                (BREWMODE > 0 && currBrewState > kBrewIdle && currBrewState <= kBrewFinished))
+            if ((timeBrewed > 0 && BREWCONTROL_TYPE == 0) ||
+                (BREWCONTROL_TYPE > 0 && currBrewState > kBrewIdle && currBrewState <= kBrewFinished))
             {
                 machineState = kBrew;
 
@@ -1049,8 +1049,8 @@ void handleMachineState() {
         case kPidNormal:
             brewDetection();
 
-            if ((timeBrewed > 0 && BREWMODE == 0) ||  // timeBrewed with Only PID
-                (BREWMODE > 0 && currBrewState > kBrewIdle && currBrewState <= kBrewFinished))
+            if ((timeBrewed > 0 && BREWCONTROL_TYPE == 0) ||
+                (BREWCONTROL_TYPE > 0 && currBrewState > kBrewIdle && currBrewState <= kBrewFinished))
             {
                 machineState = kBrew;
 
@@ -1106,14 +1106,14 @@ void handleMachineState() {
                 LOGF(DEBUG, "(tB,T,hra) --> %5.2f %6.2f %8.2f", (double)(millis() - startingTime) / 1000, temperature, tempRateAverage);
             }
 
-            if ((timeBrewed == 0 && brewDetectionMode == 3 && BREWMODE == 0) || // PID + optocoupler: optocoupler BD timeBrewed == 0 -> switch is off again
-                ((currBrewState == kBrewIdle || currBrewState == kWaitBrewOff) && BREWMODE > 0)) // Hardware BD
+            if ((timeBrewed == 0 && brewDetectionMode == 3 && BREWCONTROL_TYPE == 0) || // PID + optocoupler: optocoupler BD timeBrewed == 0 -> switch is off again
+                ((currBrewState == kBrewIdle || currBrewState == kWaitBrewOff) && BREWCONTROL_TYPE > 0)) // Hardware BD
             {
                 // delay shot timer display for voltage sensor or hw brew toggle switch (brew counter)
                 machineState = kShotTimerAfterBrew;
                 lastBrewTimeMillis = millis();  // for delay
             }
-            else if (brewDetectionMode == 1 && BREWMODE == 0 && isBrewDetected == 0) {   // SW BD, kBrew was active for set time
+            else if (brewDetectionMode == 1 && BREWCONTROL_TYPE == 0 && isBrewDetected == 0) {   // SW BD, kBrew was active for set time
                 // when Software brew is finished, direct to PID BD
                 machineState = kBrewDetectionTrailing;
             }
@@ -1178,8 +1178,8 @@ void handleMachineState() {
                 machineState = kPidNormal;
             }
 
-            if ((timeBrewed > 0 && BREWMODE == 0 && brewDetectionMode == 3) ||  // Allow brew directly after BD only when using only PID AND hardware brew switch detection
-                (BREWMODE > 0 && currBrewState > kBrewIdle && currBrewState <= kBrewFinished))
+            if ((timeBrewed > 0 && BREWCONTROL_TYPE == 0 && brewDetectionMode == 3) ||  // Allow brew directly after BD only when using BREWCONTROL_TYPE 0 AND hardware brew switch detection
+                (BREWCONTROL_TYPE > 0 && currBrewState > kBrewIdle && currBrewState <= kBrewFinished))
             {
                 machineState = kBrew;
             }
@@ -1243,7 +1243,7 @@ void handleMachineState() {
                 brewDetection();
             }
 
-            if (brewDetectionMode == 1 && BREWMODE == 0) {
+            if (brewDetectionMode == 1 && BREWCONTROL_TYPE == 0) {
                 // if machine cooled down to 2°C above setpoint, enabled PID again
                 if (tempRateAverage > 0 && temperature < brewSetpoint + 2) {
                     machineState = kPidNormal;
@@ -1731,7 +1731,7 @@ void setup() {
         .type = kDouble,
         .section = sTempSection,
         .position = 14,
-        .show = [] { return true && BREWMODE > 0; },
+        .show = [] { return true && BREWCONTROL_TYPE > 0; },
         .minValue = BREW_TIME_MIN,
         .maxValue = BREW_TIME_MAX,
         .ptr = (void *)&brewTime
@@ -1744,7 +1744,7 @@ void setup() {
         .type = kDouble,
         .section = sTempSection,
         .position = 15,
-        .show = [] { return true && BREWMODE > 0; },
+        .show = [] { return true && BREWCONTROL_TYPE > 0; },
         .minValue = PRE_INFUSION_PAUSE_MIN,
         .maxValue = PRE_INFUSION_PAUSE_MAX,
         .ptr = (void *)&preinfusionPause
@@ -1757,7 +1757,7 @@ void setup() {
         .type = kDouble,
         .section = sTempSection,
         .position = 16,
-        .show = [] { return true && BREWMODE > 0; },
+        .show = [] { return true && BREWCONTROL_TYPE > 0; },
         .minValue = PRE_INFUSION_TIME_MIN,
         .maxValue = PRE_INFUSION_TIME_MAX,
         .ptr = (void *)&preinfusion
@@ -2045,7 +2045,7 @@ void setup() {
     mqttVars["steamKp"] = []{ return &editableVars.at("STEAM_KP"); };
     mqttVars["standbyModeOn"] = []{ return &editableVars.at("STANDBY_MODE_ON"); };
 
-    if (BREWMODE > 0) {
+    if (BREWCONTROL_TYPE > 0) {
         mqttVars["brewtime"] = []{ return &editableVars.at("BREW_TIME"); };
         mqttVars["preinfusionpause"] = []{ return &editableVars.at("BREW_PREINFUSIONPAUSE"); };
         mqttVars["preinfusion"] = []{ return &editableVars.at("BREW_PREINFUSION"); };
@@ -2338,7 +2338,7 @@ void looppid() {
         checkWeight();  // Check Weight Scale in the loop
     #endif
 
-    #if (BREWMODE > 0)
+    #if (BREWCONTROL_TYPE > 0)
         brew();
     #endif
 
@@ -2369,7 +2369,7 @@ void looppid() {
 
     handleMachineState();
 
-    #if (FEATURE_SCALE == 1 && BREWMODE == 0)  // SHOTTIMER with scale
+    #if (FEATURE_SCALE == 1 && BREWCONTROL_TYPE == 0)  // SHOTTIMER with scale
         shottimerscale();
     #endif
 

--- a/src/mqtt.h
+++ b/src/mqtt.h
@@ -566,7 +566,7 @@ std::vector<DiscoveryObject> discoveryObjects = {
         #endif
     };
 
-    #if (BREWMODE == 2 || ONLYPIDSCALE == 1)
+    #if FEATURE_SCALE == 1
         discoveryObjects.push_back(currentWeight);
         discoveryObjects.push_back(scaleCalibrateButton);
         discoveryObjects.push_back(scaleTareButton);

--- a/src/scaleHandler.h
+++ b/src/scaleHandler.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#if (BREWMODE == 2 || ONLYPIDSCALE == 1)
+#if FEATURE_SCALE == 1
 
 void scaleCalibrate(HX711_ADC loadCell, int pin, sto_item_id_t name, float *calibration) {
     loadCell.setCalFactor(1.0);

--- a/src/userConfig_sample.h
+++ b/src/userConfig_sample.h
@@ -51,9 +51,9 @@ enum MACHINE {
 #define WIFICONNECTIONDELAY 10000  // delay between reconnects in ms
 
 // PID & Hardware
-#define BREWMODE 0                               // 0 = off (no brewing controll), 1 = Brew by time (with preinfusion), 2 = Brew by weight (from scale)
+#define BREWCONTROL_TYPE 0                       // 0 = off (no brewing control), 1 = Brew by time (with preinfusion), 2 = Brew by weight (from scale)
 #define FEATURE_BREWDETECTION 1                  // 0 = deactivated, 1 = activated
-#define BREWDETECTION_TYPE 1                     // 1 = Software (BREWMODE 0), 2 = Hardware BREWMODE 1 or 2, 3 = optocoupler for BREWMODE 0 
+#define BREWDETECTION_TYPE 1                     // 1 = Software (BREWCONTROL_TYPE 0), 2 = Hardware BREWCONTROL_TYPE 1 or 2, 3 = optocoupler for BREWCONTROL_TYPE 0 
 #define FEATURE_POWERSWITCH 0                    // 0 = deactivated, 1 = activated
 #define POWERSWITCH_TYPE Switch::TOGGLE          // Switch::TOGGLE or Switch::MOMENTARY (trigger)
 #define POWERSWITCH_MODE Switch::NORMALLY_OPEN   // Switch::NORMALLY_OPEN or Switch::NORMALLY_CLOSED

--- a/src/userConfig_sample.h
+++ b/src/userConfig_sample.h
@@ -51,10 +51,9 @@ enum MACHINE {
 #define WIFICONNECTIONDELAY 10000  // delay between reconnects in ms
 
 // PID & Hardware
-#define ONLYPIDSCALE 0                           // 0 = off, 1 = BREWMODE 0 with Scale
 #define BREWMODE 0                               // 0 = off (no brewing controll), 1 = Brew by time (with preinfusion), 2 = Brew by weight (from scale)
 #define FEATURE_BREWDETECTION 1                  // 0 = deactivated, 1 = activated
-#define BREWDETECTION_TYPE 1                     // 1 = Software (BREWMODE 0), 2 = Hardware (BREWMODE > 0), 3 = optocoupler for Only PID
+#define BREWDETECTION_TYPE 1                     // 1 = Software (BREWMODE 0), 2 = Hardware BREWMODE 1 or 2, 3 = optocoupler for BREWMODE 0 
 #define FEATURE_POWERSWITCH 0                    // 0 = deactivated, 1 = activated
 #define POWERSWITCH_TYPE Switch::TOGGLE          // Switch::TOGGLE or Switch::MOMENTARY (trigger)
 #define POWERSWITCH_MODE Switch::NORMALLY_OPEN   // Switch::NORMALLY_OPEN or Switch::NORMALLY_CLOSED
@@ -75,8 +74,9 @@ enum MACHINE {
 #define FEATURE_PRESSURESENSOR 0                 // 0 = deactivated, 1 = activated
 
 // Brew Scale
-#define SCALE_SAMPLES 2            // Load cell sample rate
-#define SCALE_TYPE 0               // 1 = Only a single HX711 with two channels, 0 = one HX711 per load cell
+#define FEATURE_SCALE 0                          // 0 = deactivated, 1 = activated
+#define SCALE_TYPE 0                             // 0 = one HX711 per load cell, 1 = Only a single HX711 with two channels
+#define SCALE_SAMPLES 2                          // Load cell sample rate
 
 // Backflush values
 #define FILLTIME 5000              // time in ms the pump is running

--- a/src/userConfig_sample.h
+++ b/src/userConfig_sample.h
@@ -51,11 +51,10 @@ enum MACHINE {
 #define WIFICONNECTIONDELAY 10000  // delay between reconnects in ms
 
 // PID & Hardware
-#define ONLYPID 1                                // 0 = PID and preinfusion, 1 = Only PID
-#define ONLYPIDSCALE 0                           // 0 = off , 1 = OnlyPID with Scale
-#define BREWMODE 1                               // 1 = Brew by time (with preinfusion); 2 = Brew by weight (from scale)
+#define ONLYPIDSCALE 0                           // 0 = off, 1 = BREWMODE 0 with Scale
+#define BREWMODE 0                               // 0 = off (no brewing controll), 1 = Brew by time (with preinfusion), 2 = Brew by weight (from scale)
 #define FEATURE_BREWDETECTION 1                  // 0 = deactivated, 1 = activated
-#define BREWDETECTION_TYPE 1                     // 1 = Software (Onlypid 1), 2 = Hardware (Onlypid 0), 3 = optocoupler for Only PID
+#define BREWDETECTION_TYPE 1                     // 1 = Software (BREWMODE 0), 2 = Hardware (BREWMODE > 0), 3 = optocoupler for Only PID
 #define FEATURE_POWERSWITCH 0                    // 0 = deactivated, 1 = activated
 #define POWERSWITCH_TYPE Switch::TOGGLE          // Switch::TOGGLE or Switch::MOMENTARY (trigger)
 #define POWERSWITCH_MODE Switch::NORMALLY_OPEN   // Switch::NORMALLY_OPEN or Switch::NORMALLY_CLOSED


### PR DESCRIPTION
Removed the precompiler makros ONLYPID and ONLYPIDSCALE
ONLYPID got replaced with BREWCONTROL_TYPE 0 -> No pump or valve controll enabled 
ONLYPIDSCALE got replaced with a FEATURE_ makro (FEATURE_SCALE 0 or 1) to follow the naming scheme 
When the scale is activated SHOTTIMER_TYPE 2 and BREWMODE 0 could be used to show the weight, with BREWMODE 2 weight controlls pump and valve action 