### PR TITLE
Add WebApp Manifest file

### DIFF
--- a/data/html_fragments/header.html
+++ b/data/html_fragments/header.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Clever Coffee PID</title>
     <link rel="icon" href="data:image/svg+xml,%%3Csvg%%20xmlns='http://www.w3.org/2000/svg'%%20viewBox='0%%200%%2016%%2016'%%3E%%3Ctext%%20x='0'%%20y='14'%%3E☕%%3C/text%%3E%%3C/svg%%3E" type="image/svg+xml" />
+    <link rel="manifest" href="manifest.json" />
 
     %VAR_HEADER_FONTAWESOME%
     %VAR_HEADER_BOOTSTRAP%

--- a/data/manifest.json
+++ b/data/manifest.json
@@ -1,0 +1,16 @@
+{
+    "short_name": "Clever Coffee",
+    "name": "Clever Coffee PID",
+    "icons": [
+      {
+        "src": "/img/logo.png",
+        "type": "image/png",
+        "sizes": "180x160"
+      }
+    ],
+    "id": "/",
+    "start_url": "/",
+    "display": "standalone",
+    "scope": "/",
+    "theme_color": "#6C757D"
+}

--- a/data/manifest.json
+++ b/data/manifest.json
@@ -1,6 +1,6 @@
 {
     "short_name": "Clever Coffee",
-    "name": "Clever Coffee PID",
+    "name": "Clever Coffee",
     "icons": [
       {
         "src": "/img/logo.png",

--- a/src/embeddedWebserver.h
+++ b/src/embeddedWebserver.h
@@ -490,6 +490,7 @@ void serverSetup() {
     server.serveStatic("/js", LittleFS, "/js/", "max-age=604800");
     server.serveStatic("/img", LittleFS, "/img/", "max-age=604800");  // cache for one week
     server.serveStatic("/webfonts", LittleFS, "/webfonts/", "max-age=604800");
+    server.serveStatic("/manifest.json", LittleFS, "/manifest.json", "max-age=604800");
     server.serveStatic("/", LittleFS, "/html/", "max-age=604800").setDefaultFile("index.html").setTemplateProcessor(staticProcessor);
 
     server.begin();


### PR DESCRIPTION
# Description
Added manifest file to use the WebApp like a "normal" app when added to the home screen. 
The IP should be set static, otherwise the router may give it a different IP.

# Tests
Tested with Safari on iPhone 13 Pro with iOS 17.4.

# Usage

1. Click the "Share" button
<img src="https://github.com/rancilio-pid/clevercoffee/assets/40756776/3055b9c0-a068-4b3c-a24b-dc61363a1403" width="184" height="400">

2. Click "Add to Homescreen"
<img src="https://github.com/rancilio-pid/clevercoffee/assets/40756776/4b36ffa1-32cb-4770-b2cb-93a02877ca28" width="184" height="400">

3. Click "Add"
<img src="https://github.com/rancilio-pid/clevercoffee/assets/40756776/4a0c313a-c295-4cec-9920-8d6d3cb7a44a" width="184" height="400">

4. Now it should be added on your homescreen and be used in standalone mode
<img src="https://github.com/rancilio-pid/clevercoffee/assets/40756776/d3c78b3f-1597-43cb-b37f-9b5b46bec780" width="184" height="400">

<img src="https://github.com/rancilio-pid/clevercoffee/assets/40756776/3cea8dbe-ec70-4d1b-9059-617152fe9725" width="184" height="400">