### PR TITLE
refactor brew, steam, brewdetection and optocoupler

### DIFF
--- a/src/brewHandler.h
+++ b/src/brewHandler.h
@@ -340,7 +340,6 @@ void brew() {
 
                 // disarmed button
                 currentMillisTemp = 0;
-                brewDetected = 0;  // rearm brewDetection
                 currBrewState = kBrewIdle;
                 timeBrewed = 0;
             }

--- a/src/defaults.h
+++ b/src/defaults.h
@@ -37,9 +37,7 @@ int writeSysParamsToStorage(void);
 #define AGGBTN 0                   // PID Tn (brew detection phase)
 #define AGGBTV 20                  // PID Tv (brew detection phase)
 #define BREW_TIME 25               // brew time in seconds (only used if pump is being controlled)
-#define BREW_SW_TIME 25            // keep brew PID params for this many seconds after detection (only for software BD)
 #define BREW_PID_DELAY 10          // delay until enabling PID controller during brew (no heating during this time)
-#define BD_SENSITIVITY 120         // brew detection sensitivity, be careful: if too low, then there is the risk of wrong brew detection and rising temperature
 #define PRE_INFUSION_TIME 2        // pre-infusion time in seconds
 #define PRE_INFUSION_PAUSE_TIME 5  // pre-infusion pause time in seconds
 #define SCALE_WEIGHTSETPOINT 30    // Target weight in grams

--- a/src/display/displayTemplateStandard.h
+++ b/src/display/displayTemplateStandard.h
@@ -12,7 +12,7 @@
  */
 void printScreen()
 {
-    if (((machineState == kAtSetpoint || machineState == kPidNormal || machineState == kBrewDetectionTrailing) ||
+    if (((machineState == kAtSetpoint || machineState == kPidNormal) ||
         ((machineState == kBrew || machineState == kShotTimerAfterBrew) && FEATURE_SHOTTIMER == 0) ||  // shottimer == 0, auch Bezug anzeigen
         machineState == kCoolDown || ((machineState == kInit || machineState == kColdStart) && FEATURE_HEATINGLOGO == 0) ||
         ((machineState == kPidOffline) && FEATURE_OFFLINELOGO == 0))
@@ -59,13 +59,8 @@ void printScreen()
             u8g2.setCursor(84, 36);
             u8g2.print(timeBrewed / 1000, 0);
             u8g2.print("/");
-
-            if (BREWCONTROL_TYPE == 0) {
-                u8g2.print(brewtimesoftware, 0);
-            }
-            else {
-                u8g2.print(totalBrewTime / 1000, 1);
-            }
+            u8g2.print(totalBrewTime / 1000, 1);
+            
         }
 
         // PID values over heat bar

--- a/src/display/displayTemplateTempOnly.h
+++ b/src/display/displayTemplateTempOnly.h
@@ -15,7 +15,7 @@ float blinkingtempoffset = 0.3;  // offset for blinking
  * @brief Send data to display
  */
 void printScreen() {
-    if (((machineState == kAtSetpoint || machineState == kPidNormal || machineState == kBrewDetectionTrailing) ||
+    if (((machineState == kAtSetpoint || machineState == kPidNormal ) ||
         ((machineState == kBrew || machineState == kShotTimerAfterBrew) && FEATURE_SHOTTIMER == 0) ||  // shottimer == 0, auch Bezug anzeigen
         machineState == kCoolDown || ((machineState == kInit || machineState == kColdStart) && FEATURE_HEATINGLOGO == 0) ||
         ((machineState == kPidOffline) && FEATURE_OFFLINELOGO == 0))

--- a/src/embeddedWebserver.h
+++ b/src/embeddedWebserver.h
@@ -60,7 +60,7 @@ void serverSetup();
 void setEepromWriteFcn(int (*fcnPtr)(void));
 
 // editable vars are specified in main.cpp
-#define EDITABLE_VARS_LEN 33
+#define EDITABLE_VARS_LEN 32
 extern std::map<String, editable_t> editableVars;
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -653,11 +653,15 @@ void brewDetection() {
     if (brewDetectionMode == 0) 
     return;  
 
-    if (brewDetectionMode == 1) {  // Hardware Switch
-        if (millis() - timeBrewDetection > brewtimesoftware * 1000 && isBrewDetected == 1) {
-            isBrewDetected = 0;  // rearm brewDetection
+     if (brewDetectionMode == 1) {  // Hardware Switch
+        if (currBrewState > kBrewIdle && brewDetected == 0) {
+            LOG(DEBUG, "HW Brew detected");
+            timeBrewDetection = millis();
+            isBrewDetected = 1;
+            brewDetected = 1;
         }
     }
+
     else if (brewDetectionMode == 2) { // optocoupler
         // timeBrewed counter
         if ((digitalRead(PIN_BREWSWITCH) == optocouplerOn) && brewDetected == 1) {
@@ -677,16 +681,6 @@ void brewDetection() {
         }
     }
 
-    // Activate brew detection
-
- if (brewDetectionMode == 1) {  // Hardware Switch
-        if (currBrewState > kBrewIdle && brewDetected == 0) {
-            LOG(DEBUG, "HW Brew detected");
-            timeBrewDetection = millis();
-            isBrewDetected = 1;
-            brewDetected = 1;
-        }
-    }
     else if (brewDetectionMode == 2) {  // optocoupler
         switch (machine) {
             case QuickMill:

--- a/src/steamHandler.h
+++ b/src/steamHandler.h
@@ -20,20 +20,6 @@ void checkSteamSwitch() {
             if (steamSwitchReading == LOW && !steamFirstON) {
                 steamON = 0;
             }
-
-            // monitor QuickMill thermoblock steam-mode
-            if (machine == QuickMill) {
-                if (steamQM_active == true) {
-                    if (checkSteamOffQM() == true) {  // if true: steam-mode can be turned off
-                        steamON = 0;
-                        steamQM_active = false;
-                        lastTimeOptocouplerOn = 0;
-                    }
-                    else {
-                        steamON = 1;
-                    }
-                }
-            }
         }
         else if (STEAMSWITCH_TYPE == Switch::MOMENTARY) {
             if (steamSwitchReading != currStateSteamSwitch) {

--- a/src/storage.h
+++ b/src/storage.h
@@ -93,18 +93,18 @@ typedef struct __attribute__((packed)) {
     uint8_t freeToUse8[2];
     double pidTvBd;
     uint8_t freeToUse9[2];
-    double brewSwTimeSec;
+    double freeToUse10;
     double brewPIDDelaySec;
-    uint8_t freeToUse10;
-    double brewDetectionThreshold;
+    uint8_t freeToUse11;
+    double freeToUse12;
     uint8_t wifiCredentialsSaved;
     uint8_t useStartPonM;
     double pidKpStart;
-    uint8_t freeToUse12[2];
+    uint8_t freeToUse13[2];
     uint8_t softApEnabledCheck;
-    uint8_t freeToUse13[9];
+    uint8_t freeToUse14[9];
     double pidTnStart;
-    uint8_t freeToUse14[2];
+    uint8_t freeToUse15[2];
     char wifiSSID[25 + 1];
     char wifiPassword[25 + 1];
     double weightSetpoint;
@@ -128,7 +128,7 @@ static const sto_data_t itemDefaults PROGMEM = {
     TEMPOFFSET,                               // STO_ITEM_BREW_TEMP_OFFSET
     0xFF,                                     // free to use
     BREW_TIME,                                // STO_ITEM_BREW_TIME
-    SCALE_CALIBRATION_FACTOR,                 //STO_ITEM_SCALE_CALIBRATION_FACTOR
+    SCALE_CALIBRATION_FACTOR,                 // STO_ITEM_SCALE_CALIBRATION_FACTOR
     PRE_INFUSION_TIME,                        // STO_ITEM_PRE_INFUSION_TIME
     SCALE_KNOWN_WEIGHT,                       // STO_ITEM_SCALE_KNOWN_WEIGHT
     PRE_INFUSION_PAUSE_TIME,                  // STO_ITEM_PRE_INFUSION_PAUSE
@@ -142,10 +142,10 @@ static const sto_data_t itemDefaults PROGMEM = {
     {0xFF, 0xFF},                             // free to use
     AGGBTV,                                   // STO_ITEM_PID_TV_BD
     {0xFF, 0xFF},                             // free to use
-    BREW_SW_TIME,                             // STO_ITEM_BREW_SW_TIME
+    0xFF,                                     // free to use
     BREW_PID_DELAY,                           // STO_ITEM_BREW_PID_DELAY
     0xFF,                                     // free to use
-    BD_SENSITIVITY,                           // STO_ITEM_BD_THRESHOLD
+    0xFF,                                     // free to use
     WIFI_CREDENTIALS_SAVED,                   // STO_ITEM_WIFI_CREDENTIALS_SAVED
     0,                                        // STO_ITEM_USE_START_PON_M
     STARTKP,                                  // STO_ITEM_PID_KP_START
@@ -247,16 +247,6 @@ static inline int32_t getItemAddr(sto_item_id_t itemId, uint16_t* maxItemSize = 
         case STO_ITEM_PID_TV_BD:
             addr = offsetof(sto_data_t, pidTvBd);
             size = STRUCT_MEMBER_SIZE(sto_data_t, pidTvBd);
-            break;
-
-        case STO_ITEM_BREW_SW_TIME:
-            addr = offsetof(sto_data_t, brewSwTimeSec);
-            size = STRUCT_MEMBER_SIZE(sto_data_t, brewSwTimeSec);
-            break;
-
-        case STO_ITEM_BD_THRESHOLD:
-            addr = offsetof(sto_data_t, brewDetectionThreshold);
-            size = STRUCT_MEMBER_SIZE(sto_data_t, brewDetectionThreshold);
             break;
 
         case STO_ITEM_WIFI_CREDENTIALS_SAVED:

--- a/src/userConfig_sample.h
+++ b/src/userConfig_sample.h
@@ -52,8 +52,6 @@ enum MACHINE {
 
 // PID & Hardware
 #define BREWCONTROL_TYPE 0                       // 0 = off (no brewing control), 1 = Brew by time (with preinfusion), 2 = Brew by weight (from scale)
-#define FEATURE_BREWDETECTION 0                  // 0 = deactivated, 1 = activated
-#define BREWDETECTION_TYPE 1                     // 1 = Hardware BREWCONTROL_TYPE 1 or 2, 2 = optocoupler for BREWCONTROL_TYPE 0 
 #define FEATURE_POWERSWITCH 0                    // 0 = deactivated, 1 = activated
 #define POWERSWITCH_TYPE Switch::TOGGLE          // Switch::TOGGLE or Switch::MOMENTARY (trigger)
 #define POWERSWITCH_MODE Switch::NORMALLY_OPEN   // Switch::NORMALLY_OPEN or Switch::NORMALLY_CLOSED

--- a/src/userConfig_sample.h
+++ b/src/userConfig_sample.h
@@ -52,8 +52,8 @@ enum MACHINE {
 
 // PID & Hardware
 #define BREWCONTROL_TYPE 0                       // 0 = off (no brewing control), 1 = Brew by time (with preinfusion), 2 = Brew by weight (from scale)
-#define FEATURE_BREWDETECTION 1                  // 0 = deactivated, 1 = activated
-#define BREWDETECTION_TYPE 1                     // 1 = Software (BREWCONTROL_TYPE 0), 2 = Hardware BREWCONTROL_TYPE 1 or 2, 3 = optocoupler for BREWCONTROL_TYPE 0 
+#define FEATURE_BREWDETECTION 0                  // 0 = deactivated, 1 = activated
+#define BREWDETECTION_TYPE 1                     // 1 = Hardware BREWCONTROL_TYPE 1 or 2, 2 = optocoupler for BREWCONTROL_TYPE 0 
 #define FEATURE_POWERSWITCH 0                    // 0 = deactivated, 1 = activated
 #define POWERSWITCH_TYPE Switch::TOGGLE          // Switch::TOGGLE or Switch::MOMENTARY (trigger)
 #define POWERSWITCH_MODE Switch::NORMALLY_OPEN   // Switch::NORMALLY_OPEN or Switch::NORMALLY_CLOSED
@@ -62,7 +62,6 @@ enum MACHINE {
 #define BREWSWITCH_MODE Switch::NORMALLY_OPEN    // Switch::NORMALLY_OPEN or Switch::NORMALLY_CLOSED
 #define FEATURE_STEAMSWITCH 0                    // 0 = deactivated, 1 = activated
 #define STEAMSWITCH_TYPE Switch::TOGGLE          // Switch::TOGGLE or Switch::MOMENTARY (trigger)
-#define OPTOCOUPLER_TYPE HIGH                    // BREWDETECTION 3 configuration; HIGH or LOW trigger optocoupler
 #define STEAMSWITCH_MODE Switch::NORMALLY_OPEN   // Switch::NORMALLY_OPEN or Switch::NORMALLY_CLOSED
 #define HEATER_SSR_TYPE Relay::HIGH_TRIGGER      // HIGH_TRIGGER = relay switches when input is HIGH, vice versa for LOW_TRIGGER
 #define PUMP_VALVE_SSR_TYPE Relay::HIGH_TRIGGER  // HIGH_TRIGGER = relay switches when input is HIGH, vice versa for LOW_TRIGGER


### PR DESCRIPTION
this PR will remove the software brewdetection.
also steam over optocoupler for quickmill.
on default there will be no brewdetection anymore.
Since we change the behavior of the PID in total and we do not recommend heating during brew, there is no need for SW brewdetection.
On top there is a lot of code, that specialy is waiting because of SW brewdetection.
If someone want BREW PID, having some sort of hardware brewdetection (switch or optocoupler), is needed.
If we add brew detection with a reed sensor on the valve, the impact of adding a hardware brew detection is reduced.

During this PR i also want to rename Brewdection flags and variables, the fit our naming sheme and get this all a bit nicer.
Also there is maybe a bug that our main state mashine dosen´t travel back from ksteam to kpidnormal, when no brewdetection is enabled. This has to be fixed with this pr, or it isn´t possible to remove sw bredetection.

TODO:
Check code in total if anywhere some sw brewdecetion code is left
refactor brew, steam, brewdetection where neede, part of shotimer
rename variables
real world testing.


ANY help is highly welcome, feel free to comment and discuss. Or make PRs on my branch.