### PR TITLE
Drop Cooldown State

### DIFF
--- a/src/display/displayTemplateScale.h
+++ b/src/display/displayTemplateScale.h
@@ -5,6 +5,7 @@
  *
  */
 
+#pragma once
 #include "displayCommon.h"
 
 /**

--- a/src/display/displayTemplateStandard.h
+++ b/src/display/displayTemplateStandard.h
@@ -5,6 +5,7 @@
  *
  */
 
+#pragma once
 #include "displayCommon.h"
 
 /**

--- a/src/display/displayTemplateUpright.h
+++ b/src/display/displayTemplateUpright.h
@@ -19,7 +19,7 @@ void printScreen() {
 
     // If no specific machine state was printed, print default:
     if (((machineState == kPidNormal || machineState == kBrewDetectionTrailing) || ((machineState == kBrew || machineState == kShotTimerAfterBrew) && FEATURE_SHOTTIMER == 0) || // shottimer == 0, auch Bezug anzeigen
-         machineState == kCoolDown || (machineState == kPidNormal && (setpoint - temperature) > 5. && FEATURE_HEATINGLOGO == 0) || ((machineState == kPidDisabled) && FEATURE_PIDOFF_LOGO == 0)) &&
+         (machineState == kPidNormal && (setpoint - temperature) > 5. && FEATURE_HEATINGLOGO == 0) || ((machineState == kPidDisabled) && FEATURE_PIDOFF_LOGO == 0)) &&
         (brewSwitchState != kBrewSwitchFlushOff)) {
         if (!sensorError) {
             u8g2.clearBuffer();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -276,7 +276,7 @@ SysPara<float> sysParaScaleKnownWeight(&scaleKnownWeight, 0, 2000, STO_ITEM_SCAL
 
 // Other variables
 boolean emergencyStop = false;                // Emergency stop if temperature is too high
-double EmergencyStopTemp = 120;               // Temp EmergencyStopTemp
+const double EmergencyStopTemp = 145;         // Temp EmergencyStopTemp
 float inX = 0, inY = 0, inOld = 0, inSum = 0; // used for filterPressureValue()
 boolean brewDetected = 0;
 boolean setupDone = false;
@@ -678,10 +678,6 @@ float filterPressureValue(float input) {
     inOld = inSum;
 
     return inSum;
-}
-
-void setEmergencyStopTemp() {
-    EmergencyStopTemp = 145;
 }
 
 void initSteamQM() {
@@ -1850,8 +1846,6 @@ void looppid() {
     else if (steamON == 0) {
         setpoint = brewSetpoint;
     }
-
-    setEmergencyStopTemp();
 
     updateStandbyTimer();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -84,7 +84,6 @@ enum MachineState {
     kShotTimerAfterBrew = 31,
     kBrewDetectionTrailing = 35,
     kSteam = 40,
-    kCoolDown = 45,
     kBackflush = 50,
     kWaterEmpty = 70,
     kEmergencyStop = 80,
@@ -682,12 +681,7 @@ float filterPressureValue(float input) {
 }
 
 void setEmergencyStopTemp() {
-    if (machineState == kSteam || machineState == kCoolDown) {
-        if (EmergencyStopTemp != 145) EmergencyStopTemp = 145;
-    }
-    else {
-        if (EmergencyStopTemp != 120) EmergencyStopTemp = 120;
-    }
+    EmergencyStopTemp = 145;
 }
 
 void initSteamQM() {
@@ -898,60 +892,12 @@ void handleMachineState() {
             break;
 
         case kSteam:
-            if (steamON == 0) {
-                machineState = kCoolDown;
-            }
-
             if (emergencyStop) {
                 machineState = kEmergencyStop;
             }
 
             if (backflushOn || backflushState > kBackflushWaitBrewswitchOn) {
                 machineState = kBackflush;
-            }
-
-            if (pidON == 0) {
-                machineState = kPidDisabled;
-            }
-
-            if (!waterFull) {
-                machineState = kWaterEmpty;
-            }
-
-            if (tempSensor->hasError()) {
-                machineState = kSensorError;
-            }
-            break;
-
-        case kCoolDown:
-            if (brewDetectionMode == 2 || brewDetectionMode == 3) {
-                /* For quickmill: steam detection only via switch, calling
-                 * brewDetection() detects new steam request
-                 */
-                brewDetection();
-            }
-
-            if (brewDetectionMode == 1 && BREWCONTROL_TYPE == 0) {
-                // if machine cooled down to 2°C above setpoint, enabled PID again
-                if (tempSensor->getAverageTemperatureRate() > 0 && temperature < brewSetpoint + 2) {
-                    machineState = kPidNormal;
-                }
-            }
-
-            if ((brewDetectionMode == 3 || brewDetectionMode == 2) && temperature < brewSetpoint + 2) {
-                machineState = kPidNormal;
-            }
-
-            if (steamON == 1) {
-                machineState = kSteam;
-            }
-
-            if (backflushOn || backflushState > kBackflushWaitBrewswitchOn) {
-                machineState = kBackflush;
-            }
-
-            if (emergencyStop) {
-                machineState = kEmergencyStop;
             }
 
             if (pidON == 0) {
@@ -1094,8 +1040,6 @@ char const* machinestateEnumToString(MachineState machineState) {
             return "Brew Detection Trailing";
         case kSteam:
             return "Steam";
-        case kCoolDown:
-            return "Cool Down";
         case kBackflush:
             return "Backflush";
         case kWaterEmpty:
@@ -1993,35 +1937,6 @@ void looppid() {
         }
 
         bPID.SetTunings(steamKp, 0, 0, 1);
-    }
-
-    // chill-mode after steam
-    if (machineState == kCoolDown) {
-        switch (machine) {
-            case QuickMill:
-                aggbKp = 150;
-                aggbKi = 0;
-                aggbKd = 0;
-                break;
-
-            default:
-                // calc ki, kd
-                if (aggbTn != 0) {
-                    aggbKi = aggbKp / aggbTn;
-                }
-                else {
-                    aggbKi = 0;
-                }
-
-                aggbKd = aggbTv * aggbKp;
-        }
-
-        if (lastmachinestatepid != machineState) {
-            LOGF(DEBUG, "new PID-Values: P=%.1f  I=%.1f  D=%.1f", aggbKp, aggbKi, aggbKd);
-            lastmachinestatepid = machineState;
-        }
-
-        bPID.SetTunings(aggbKp, aggbKi, aggbKd, 1);
     }
     // sensor error OR Emergency Stop
 }


### PR DESCRIPTION
This MR does two things:

* It drops the `kCooldown` state since that just meant PID off (which is anyway the case because we're off the target value) and seeting a different emergency temperature
* It fixes a single emergency temperature to 145degC instead of swapping between 120 and 145. This is more like the original Silvia hardware where a single thermostat is used for the emergency shutoff (still in use)
