### PR TITLE
Display: Simplify updating display

### DIFF
--- a/src/display/displayCommon.h
+++ b/src/display/displayCommon.h
@@ -309,7 +309,7 @@ void displayShottimer(void) {
 /**
  * @brief display heating logo
  */
-void displayMachineState() {
+bool displayMachineState() {
     // Show the heating logo when we are in regular PID mode and more than 5degC below the set point
     if (FEATURE_HEATINGLOGO > 0 && machineState == kPidNormal && (setpoint - temperature) > 5. && brewSwitchState != kBrewSwitchFlushOff) {
         // For status info
@@ -324,10 +324,10 @@ void displayMachineState() {
         u8g2.drawCircle(122, 32, 3);
 
         u8g2.sendBuffer();
+        return true;
     }
-
     // Offline logo
-    if (FEATURE_PIDOFF_LOGO == 1 && machineState == kPidDisabled) {
+    else if (FEATURE_PIDOFF_LOGO == 1 && machineState == kPidDisabled) {
         u8g2.clearBuffer();
         u8g2.drawXBMP(38, 0, Off_Logo_width, Off_Logo_height, Off_Logo);
         u8g2.setCursor(0, 55);
@@ -335,9 +335,9 @@ void displayMachineState() {
         u8g2.print("PID is disabled manually");
         displayWaterIcon(119, 1);
         u8g2.sendBuffer();
+        return true;
     }
-
-    if (FEATURE_PIDOFF_LOGO == 1 && machineState == kStandby) {
+    else if (FEATURE_PIDOFF_LOGO == 1 && machineState == kStandby) {
         u8g2.clearBuffer();
         u8g2.drawXBMP(38, 0, Off_Logo_width, Off_Logo_height, Off_Logo);
         u8g2.setCursor(36, 55);
@@ -345,10 +345,10 @@ void displayMachineState() {
         u8g2.print("Standby mode");
         displayWaterIcon(119, 1);
         u8g2.sendBuffer();
+        return true;
     }
-
     // Steam
-    if (machineState == kSteam && brewSwitchState != kBrewSwitchFlushOff) {
+    else if (machineState == kSteam && brewSwitchState != kBrewSwitchFlushOff) {
         u8g2.clearBuffer();
         u8g2.drawXBMP(-1, 12, Steam_Logo_width, Steam_Logo_height, Steam_Logo);
 
@@ -356,18 +356,18 @@ void displayMachineState() {
 
         displayWaterIcon(119, 1);
         u8g2.sendBuffer();
+        return true;
     }
-
     // Water empty
-    if (machineState == kWaterEmpty && brewSwitchState != kBrewSwitchFlushOff) {
+    else if (machineState == kWaterEmpty && brewSwitchState != kBrewSwitchFlushOff) {
         u8g2.clearBuffer();
         u8g2.drawXBMP(45, 0, Water_Empty_Logo_width, Water_Empty_Logo_height, Water_Empty_Logo);
         u8g2.setFont(u8g2_font_profont11_tf);
         u8g2.sendBuffer();
+        return true;
     }
-
     // Backflush
-    if (machineState == kBackflush) {
+    else if (machineState == kBackflush) {
         u8g2.clearBuffer();
         u8g2.setFont(u8g2_font_fub17_tf);
         u8g2.setCursor(2, 10);
@@ -401,10 +401,10 @@ void displayMachineState() {
 
         displayWaterIcon(119, 1);
         u8g2.sendBuffer();
+        return true;
     }
-
     // PID Off
-    if (machineState == kEmergencyStop) {
+    else if (machineState == kEmergencyStop) {
         u8g2.clearBuffer();
         u8g2.setFont(u8g2_font_profont11_tf);
         u8g2.setCursor(32, 24);
@@ -432,18 +432,21 @@ void displayMachineState() {
         displayWaterIcon(119, 1);
 
         u8g2.sendBuffer();
+        return true;
     }
-
-    if (machineState == kSensorError) {
+    else if (machineState == kSensorError) {
         u8g2.clearBuffer();
         u8g2.setFont(u8g2_font_profont11_tf);
         displayMessage(langstring_error_tsensor[0], String(temperature), langstring_error_tsensor[1], "", "", "");
+        return true;
     }
-
-    if (machineState == kEepromError) {
+    else if (machineState == kEepromError) {
         u8g2.clearBuffer();
         u8g2.setFont(u8g2_font_profont11_tf);
         displayMessage("EEPROM Error, please set Values", "", "", "", "", "");
+        return true;
     }
+
+    return false;
 }
 #endif

--- a/src/display/displayCommon.h
+++ b/src/display/displayCommon.h
@@ -236,9 +236,9 @@ void displayLogo(String displaymessagetext, String displaymessagetext2) {
 /**
  * @brief display shot timer
  */
-void displayShottimer(void) {
+bool displayShottimer() {
     if (FEATURE_SHOTTIMER == 0) {
-        return;
+        return false;
     }
 
     if ((machineState == kBrew || brewSwitchState == kBrewSwitchFlushOff) && SHOTTIMER_TYPE == 1) {
@@ -255,13 +255,14 @@ void displayShottimer(void) {
 
         displayWaterIcon(119, 1);
         u8g2.sendBuffer();
+        return true;
     }
 
     /* if the totalBrewTime is reached automatically,
      * nothing should be done, otherwise wrong time is displayed
      * because the switch is pressed later than totalBrewTime
      */
-    if ((machineState == kShotTimerAfterBrew && brewSwitchState != kBrewSwitchFlushOff) && SHOTTIMER_TYPE == 1) {
+    else if ((machineState == kShotTimerAfterBrew && brewSwitchState != kBrewSwitchFlushOff) && SHOTTIMER_TYPE == 1) {
         u8g2.clearBuffer();
         u8g2.drawXBMP(-1, 11, Brew_Cup_Logo_width, Brew_Cup_Logo_height, Brew_Cup_Logo);
 
@@ -269,10 +270,11 @@ void displayShottimer(void) {
 
         displayWaterIcon(119, 1);
         u8g2.sendBuffer();
+        return true;
     }
 
 #if FEATURE_SCALE == 1
-    if ((machineState == kBrew) && SHOTTIMER_TYPE == 2) {
+    else if ((machineState == kBrew) && SHOTTIMER_TYPE == 2) {
         u8g2.clearBuffer();
 
         // temp icon
@@ -287,9 +289,10 @@ void displayShottimer(void) {
         u8g2.setFont(u8g2_font_profont11_tf);
         displayWaterIcon(119, 1);
         u8g2.sendBuffer();
+        return true;
     }
 
-    if (((machineState == kShotTimerAfterBrew) && SHOTTIMER_TYPE == 2)) {
+    else if (((machineState == kShotTimerAfterBrew) && SHOTTIMER_TYPE == 2)) {
         u8g2.clearBuffer();
         u8g2.drawXBMP(-1, 11, Brew_Cup_Logo_width, Brew_Cup_Logo_height, Brew_Cup_Logo);
         u8g2.setFont(u8g2_font_profont22_tf);
@@ -302,8 +305,10 @@ void displayShottimer(void) {
         u8g2.setFont(u8g2_font_profont11_tf);
         displayWaterIcon(119, 1);
         u8g2.sendBuffer();
+        return true;
     }
 #endif
+    return false;
 }
 
 /**

--- a/src/display/displayRotateUpright.h
+++ b/src/display/displayRotateUpright.h
@@ -87,7 +87,7 @@ void displayEmergencyStop(void) {
 /**
  * @brief display shot timer
  */
-void displayShottimer(void) {
+bool displayShottimer() {
     if (((timeBrewed > 0 && BREWCONTROL_TYPE == 0) || (BREWCONTROL_TYPE > 0 && currBrewState > kBrewIdle && currBrewState <= kBrewFinished)) && FEATURE_SHOTTIMER == 1 && SHOTTIMER_TYPE == 1) {
         u8g2.clearBuffer();
 
@@ -98,11 +98,11 @@ void displayShottimer(void) {
         u8g2.print(timeBrewed / 1000, 1);
         u8g2.setFont(u8g2_font_profont11_tf);
         u8g2.sendBuffer();
+        return true;
     }
-
-    if (FEATURE_SHOTTIMER == 1 && SHOTTIMER_TYPE == 1 && millis() >= lastBrewTimeMillis && // directly after creating lastbrewTimeMillis (happens when turning off the brew switch, case 43 in the code) should be started
-        lastBrewTimeMillis + SHOTTIMERDISPLAYDELAY >= millis() &&                          // should run until millis() has caught up with SHOTTIMERDISPLAYDELAY, this can be used to control the display duration
-        lastBrewTimeMillis < totalBrewTime) // if the totalBrewTime is reached automatically, nothing should be done, otherwise wrong time will be displayed because switch is pressed later than totalBrewTime
+    else if (FEATURE_SHOTTIMER == 1 && SHOTTIMER_TYPE == 1 && millis() >= lastBrewTimeMillis && // directly after creating lastbrewTimeMillis (happens when turning off the brew switch, case 43 in the code) should be started
+             lastBrewTimeMillis + SHOTTIMERDISPLAYDELAY >= millis() &&                          // should run until millis() has caught up with SHOTTIMERDISPLAYDELAY, this can be used to control the display duration
+             lastBrewTimeMillis < totalBrewTime) // if the totalBrewTime is reached automatically, nothing should be done, otherwise wrong time will be displayed because switch is pressed later than totalBrewTime
     {
         u8g2.clearBuffer();
         u8g2.drawXBMP(0, 0, Brew_Cup_Logo_width, Brew_Cup_Logo_height, Brew_Cup_Logo);
@@ -111,5 +111,8 @@ void displayShottimer(void) {
         u8g2.print((lastBrewTimeMillis - startingTime) / 1000, 1);
         u8g2.setFont(u8g2_font_profont11_tf);
         u8g2.sendBuffer();
+        return true;
     }
+
+    return false
 }

--- a/src/display/displayTemplateMinimal.h
+++ b/src/display/displayTemplateMinimal.h
@@ -14,86 +14,93 @@
  */
 void printScreen() {
 
+    // Show shot timer:
+    if (displayShottimer()) {
+        // Display was updated, end here
+        return;
+    }
+
     // Print the machine state
-    auto display_updated = displayMachineState();
+    if (displayMachineState()) {
+        // Display was updated, end here
+        return;
+    }
 
     // If no specific machine state was printed, print default:
-    if (!display_updated) {
-        u8g2.clearBuffer();
+    u8g2.clearBuffer();
 
-        displayStatusbar();
+    displayStatusbar();
 
-        int numDecimalsInput = 1;
+    int numDecimalsInput = 1;
 
-        if (temperature > 99.999) {
-            numDecimalsInput = 0;
-        }
+    if (temperature > 99.999) {
+        numDecimalsInput = 0;
+    }
 
-        int numDecimalsSetpoint = 1;
+    int numDecimalsSetpoint = 1;
 
-        if (setpoint > 99.999) {
-            numDecimalsSetpoint = 0;
-        }
+    if (setpoint > 99.999) {
+        numDecimalsSetpoint = 0;
+    }
 
-        // Draw temp, blink if feature STATUS_LED is not enabled
-        if ((fabs(temperature - setpoint) < 0.3) && !FEATURE_STATUS_LED) {
-            if (isrCounter < 500) {
-                // limit to 4 characters
-                u8g2.setCursor(2, 20);
-                u8g2.setFont(u8g2_font_profont22_tf);
-                u8g2.print(temperature, numDecimalsInput);
-                u8g2.setFont(u8g2_font_open_iconic_arrow_2x_t);
-                u8g2.print(char(78));
-                u8g2.setCursor(78, 20);
-                u8g2.setFont(u8g2_font_profont22_tf);
-                u8g2.print(setpoint, numDecimalsSetpoint);
-            }
-        }
-        else {
+    // Draw temp, blink if feature STATUS_LED is not enabled
+    if ((fabs(temperature - setpoint) < 0.3) && !FEATURE_STATUS_LED) {
+        if (isrCounter < 500) {
+            // limit to 4 characters
             u8g2.setCursor(2, 20);
             u8g2.setFont(u8g2_font_profont22_tf);
             u8g2.print(temperature, numDecimalsInput);
             u8g2.setFont(u8g2_font_open_iconic_arrow_2x_t);
-            u8g2.setCursor(56, 24);
-
-            if (bPID.GetMode() == 1) {
-                u8g2.print(char(74));
-            }
-            else {
-                u8g2.print(char(70));
-            }
-
-            u8g2.setCursor(79, 20);
+            u8g2.print(char(78));
+            u8g2.setCursor(78, 20);
             u8g2.setFont(u8g2_font_profont22_tf);
             u8g2.print(setpoint, numDecimalsSetpoint);
         }
+    }
+    else {
+        u8g2.setCursor(2, 20);
+        u8g2.setFont(u8g2_font_profont22_tf);
+        u8g2.print(temperature, numDecimalsInput);
+        u8g2.setFont(u8g2_font_open_iconic_arrow_2x_t);
+        u8g2.setCursor(56, 24);
 
-        u8g2.setFont(u8g2_font_profont11_tf);
+        if (bPID.GetMode() == 1) {
+            u8g2.print(char(74));
+        }
+        else {
+            u8g2.print(char(70));
+        }
 
-        if (isBrewDetected == 1 && currBrewState == kBrewIdle) {
-            u8g2.setCursor(38, 44);
-            u8g2.print("BD: ");
-            u8g2.print((millis() - timeBrewDetection) / 1000, 1);
-            u8g2.print("/");
+        u8g2.setCursor(79, 20);
+        u8g2.setFont(u8g2_font_profont22_tf);
+        u8g2.print(setpoint, numDecimalsSetpoint);
+    }
+
+    u8g2.setFont(u8g2_font_profont11_tf);
+
+    if (isBrewDetected == 1 && currBrewState == kBrewIdle) {
+        u8g2.setCursor(38, 44);
+        u8g2.print("BD: ");
+        u8g2.print((millis() - timeBrewDetection) / 1000, 1);
+        u8g2.print("/");
+        u8g2.print(brewtimesoftware, 0);
+    }
+    else {
+        u8g2.setCursor(34, 44);
+        u8g2.print(langstring_brew);
+        u8g2.print(timeBrewed / 1000, 0);
+        u8g2.print("/");
+
+        if (BREWCONTROL_TYPE == 0) {
             u8g2.print(brewtimesoftware, 0);
         }
         else {
-            u8g2.setCursor(34, 44);
-            u8g2.print(langstring_brew);
-            u8g2.print(timeBrewed / 1000, 0);
-            u8g2.print("/");
-
-            if (BREWCONTROL_TYPE == 0) {
-                u8g2.print(brewtimesoftware, 0);
-            }
-            else {
-                u8g2.print(totalBrewTime / 1000, 0);
-            }
+            u8g2.print(totalBrewTime / 1000, 0);
         }
-
-        // Show heater output in %
-        displayProgressbar(pidOutput / 10, 15, 60, 100);
-
-        u8g2.sendBuffer();
     }
+
+    // Show heater output in %
+    displayProgressbar(pidOutput / 10, 15, 60, 100);
+
+    u8g2.sendBuffer();
 }

--- a/src/display/displayTemplateMinimal.h
+++ b/src/display/displayTemplateMinimal.h
@@ -7,90 +7,93 @@
 
 #pragma once
 
+#include "displayCommon.h"
+
 /**
  * @brief Send data to display
  */
 void printScreen() {
-    if (((machineState == kPidNormal || machineState == kBrewDetectionTrailing) || ((machineState == kBrew || machineState == kShotTimerAfterBrew) && FEATURE_SHOTTIMER == 0) || machineState == kCoolDown ||
-         (machineState == kPidNormal && (setpoint - temperature) > 5. && FEATURE_HEATINGLOGO == 0) || ((machineState == kPidDisabled) && FEATURE_PIDOFF_LOGO == 0)) &&
-        (brewSwitchState != kBrewSwitchFlushOff)) {
-        if (!sensorError) {
-            u8g2.clearBuffer();
 
-            displayStatusbar();
+    // Print the machine state
+    auto display_updated = displayMachineState();
 
-            int numDecimalsInput = 1;
+    // If no specific machine state was printed, print default:
+    if (!display_updated) {
+        u8g2.clearBuffer();
 
-            if (temperature > 99.999) {
-                numDecimalsInput = 0;
-            }
+        displayStatusbar();
 
-            int numDecimalsSetpoint = 1;
+        int numDecimalsInput = 1;
 
-            if (setpoint > 99.999) {
-                numDecimalsSetpoint = 0;
-            }
+        if (temperature > 99.999) {
+            numDecimalsInput = 0;
+        }
 
-            // Draw temp, blink if feature STATUS_LED is not enabled
-            if ((fabs(temperature - setpoint) < 0.3) && !FEATURE_STATUS_LED) {
-                if (isrCounter < 500) {
-                    // limit to 4 characters
-                    u8g2.setCursor(2, 20);
-                    u8g2.setFont(u8g2_font_profont22_tf);
-                    u8g2.print(temperature, numDecimalsInput);
-                    u8g2.setFont(u8g2_font_open_iconic_arrow_2x_t);
-                    u8g2.print(char(78));
-                    u8g2.setCursor(78, 20);
-                    u8g2.setFont(u8g2_font_profont22_tf);
-                    u8g2.print(setpoint, numDecimalsSetpoint);
-                }
-            }
-            else {
+        int numDecimalsSetpoint = 1;
+
+        if (setpoint > 99.999) {
+            numDecimalsSetpoint = 0;
+        }
+
+        // Draw temp, blink if feature STATUS_LED is not enabled
+        if ((fabs(temperature - setpoint) < 0.3) && !FEATURE_STATUS_LED) {
+            if (isrCounter < 500) {
+                // limit to 4 characters
                 u8g2.setCursor(2, 20);
                 u8g2.setFont(u8g2_font_profont22_tf);
                 u8g2.print(temperature, numDecimalsInput);
                 u8g2.setFont(u8g2_font_open_iconic_arrow_2x_t);
-                u8g2.setCursor(56, 24);
-
-                if (bPID.GetMode() == 1) {
-                    u8g2.print(char(74));
-                }
-                else {
-                    u8g2.print(char(70));
-                }
-
-                u8g2.setCursor(79, 20);
+                u8g2.print(char(78));
+                u8g2.setCursor(78, 20);
                 u8g2.setFont(u8g2_font_profont22_tf);
                 u8g2.print(setpoint, numDecimalsSetpoint);
             }
+        }
+        else {
+            u8g2.setCursor(2, 20);
+            u8g2.setFont(u8g2_font_profont22_tf);
+            u8g2.print(temperature, numDecimalsInput);
+            u8g2.setFont(u8g2_font_open_iconic_arrow_2x_t);
+            u8g2.setCursor(56, 24);
 
-            u8g2.setFont(u8g2_font_profont11_tf);
+            if (bPID.GetMode() == 1) {
+                u8g2.print(char(74));
+            }
+            else {
+                u8g2.print(char(70));
+            }
 
-            if (isBrewDetected == 1 && currBrewState == kBrewIdle) {
-                u8g2.setCursor(38, 44);
-                u8g2.print("BD: ");
-                u8g2.print((millis() - timeBrewDetection) / 1000, 1);
-                u8g2.print("/");
+            u8g2.setCursor(79, 20);
+            u8g2.setFont(u8g2_font_profont22_tf);
+            u8g2.print(setpoint, numDecimalsSetpoint);
+        }
+
+        u8g2.setFont(u8g2_font_profont11_tf);
+
+        if (isBrewDetected == 1 && currBrewState == kBrewIdle) {
+            u8g2.setCursor(38, 44);
+            u8g2.print("BD: ");
+            u8g2.print((millis() - timeBrewDetection) / 1000, 1);
+            u8g2.print("/");
+            u8g2.print(brewtimesoftware, 0);
+        }
+        else {
+            u8g2.setCursor(34, 44);
+            u8g2.print(langstring_brew);
+            u8g2.print(timeBrewed / 1000, 0);
+            u8g2.print("/");
+
+            if (BREWCONTROL_TYPE == 0) {
                 u8g2.print(brewtimesoftware, 0);
             }
             else {
-                u8g2.setCursor(34, 44);
-                u8g2.print(langstring_brew);
-                u8g2.print(timeBrewed / 1000, 0);
-                u8g2.print("/");
-
-                if (BREWCONTROL_TYPE == 0) {
-                    u8g2.print(brewtimesoftware, 0);
-                }
-                else {
-                    u8g2.print(totalBrewTime / 1000, 0);
-                }
+                u8g2.print(totalBrewTime / 1000, 0);
             }
-
-            // Show heater output in %
-            displayProgressbar(pidOutput / 10, 15, 60, 100);
-
-            u8g2.sendBuffer();
         }
+
+        // Show heater output in %
+        displayProgressbar(pidOutput / 10, 15, 60, 100);
+
+        u8g2.sendBuffer();
     }
 }

--- a/src/display/displayTemplateScale.h
+++ b/src/display/displayTemplateScale.h
@@ -12,79 +12,86 @@
  */
 void printScreen() {
 
+    // Show shot timer:
+    if (displayShottimer()) {
+        // Display was updated, end here
+        return;
+    }
+
     // Print the machine state
-    auto display_updated = displayMachineState();
+    if (displayMachineState()) {
+        // Display was updated, end here
+        return;
+    }
 
     // If no specific machine state was printed, print default:
-    if (!display_updated) {
-        u8g2.clearBuffer();
+    u8g2.clearBuffer();
 
-        displayStatusbar();
+    displayStatusbar();
 
-        displayThermometerOutline(4, 62);
+    displayThermometerOutline(4, 62);
 
-        // Draw current temp in thermometer
-        if (fabs(temperature - setpoint) < 0.3) {
-            if (isrCounter < 500) {
-                drawTemperaturebar(8, 50, 30);
-            }
-        }
-        else {
+    // Draw current temp in thermometer
+    if (fabs(temperature - setpoint) < 0.3) {
+        if (isrCounter < 500) {
             drawTemperaturebar(8, 50, 30);
         }
+    }
+    else {
+        drawTemperaturebar(8, 50, 30);
+    }
 
-        u8g2.setFont(u8g2_font_profont11_tf);
+    u8g2.setFont(u8g2_font_profont11_tf);
 
-        u8g2.setCursor(32, 16);
-        u8g2.print("T: ");
-        u8g2.print(temperature, 1);
+    u8g2.setCursor(32, 16);
+    u8g2.print("T: ");
+    u8g2.print(temperature, 1);
 
-        u8g2.print("/");
-        u8g2.print(setpoint, 1);
+    u8g2.print("/");
+    u8g2.print(setpoint, 1);
 
-        u8g2.setCursor(32, 26);
-        u8g2.print("W: ");
+    u8g2.setCursor(32, 26);
+    u8g2.print("W: ");
 
-        if (scaleFailure) {
-            u8g2.print("fault");
+    if (scaleFailure) {
+        u8g2.print("fault");
+    }
+    else {
+        if (machineState == kBrew) {
+            u8g2.print(weightBrew, 0);
         }
         else {
-            if (machineState == kBrew) {
-                u8g2.print(weightBrew, 0);
-            }
-            else {
-                u8g2.print(weight, 0);
-            }
-
-            u8g2.print("/");
-            u8g2.print(weightSetpoint, 0);
-            u8g2.print(" (");
-            u8g2.print(weightBrew, 1);
-            u8g2.print(")");
+            u8g2.print(weight, 0);
         }
 
-        // Brew
-        u8g2.setCursor(32, 36);
-        u8g2.print("t: ");
-        u8g2.print(timeBrewed / 1000, 0);
         u8g2.print("/");
+        u8g2.print(weightSetpoint, 0);
+        u8g2.print(" (");
+        u8g2.print(weightBrew, 1);
+        u8g2.print(")");
+    }
 
-        if (BREWCONTROL_TYPE == 0) {
-            u8g2.print(brewtimesoftware, 0);
-        }
-        else {
-            u8g2.print(totalBrewTime / 1000, 1);
-        }
+    // Brew
+    u8g2.setCursor(32, 36);
+    u8g2.print("t: ");
+    u8g2.print(timeBrewed / 1000, 0);
+    u8g2.print("/");
+
+    if (BREWCONTROL_TYPE == 0) {
+        u8g2.print(brewtimesoftware, 0);
+    }
+    else {
+        u8g2.print(totalBrewTime / 1000, 1);
+    }
 
 #if (FEATURE_PRESSURESENSOR == 1)
-        u8g2.setCursor(32, 46);
-        u8g2.print("P: ");
-        u8g2.print(inputPressure, 1);
+    u8g2.setCursor(32, 46);
+    u8g2.print("P: ");
+    u8g2.print(inputPressure, 1);
 #endif
 
-        // Show heater output in %
-        displayProgressbar(pidOutput / 10, 30, 60, 98);
+    // Show heater output in %
+    displayProgressbar(pidOutput / 10, 30, 60, 98);
 
-        u8g2.sendBuffer();
-    }
+    u8g2.sendBuffer();
 }

--- a/src/display/displayTemplateScale.h
+++ b/src/display/displayTemplateScale.h
@@ -5,15 +5,18 @@
  *
  */
 
-#pragma once
+#include "displayCommon.h"
 
 /**
  * @brief Send data to display
  */
 void printScreen() {
-    if (((machineState == kPidNormal || machineState == kBrewDetectionTrailing) || ((machineState == kBrew || machineState == kShotTimerAfterBrew) && FEATURE_SHOTTIMER == 0) || // shottimer == 0, auch Bezug anzeigen
-         machineState == kCoolDown || (machineState == kPidNormal && (setpoint - temperature) > 5. && FEATURE_HEATINGLOGO == 0) || ((machineState == kPidDisabled) && FEATURE_PIDOFF_LOGO == 0)) &&
-        (brewSwitchState != kBrewSwitchFlushOff)) {
+
+    // Print the machine state
+    auto display_updated = displayMachineState();
+
+    // If no specific machine state was printed, print default:
+    if (!display_updated) {
         u8g2.clearBuffer();
 
         displayStatusbar();

--- a/src/display/displayTemplateStandard.h
+++ b/src/display/displayTemplateStandard.h
@@ -12,91 +12,98 @@
  */
 void printScreen() {
 
+    // Show shot timer:
+    if (displayShottimer()) {
+        // Display was updated, end here
+        return;
+    }
+
     // Print the machine state
-    auto display_updated = displayMachineState();
+    if (displayMachineState()) {
+        // Display was updated, end here
+        return;
+    }
 
     // If no specific machine state was printed, print default:
-    if (!display_updated) {
 
-        u8g2.clearBuffer();
-        u8g2.setFont(u8g2_font_profont11_tf); // set font
+    u8g2.clearBuffer();
+    u8g2.setFont(u8g2_font_profont11_tf); // set font
 
-        displayStatusbar();
+    displayStatusbar();
 
-        u8g2.setCursor(35, 16);
-        u8g2.print(langstring_current_temp);
-        u8g2.setCursor(84, 16);
-        u8g2.print(temperature, 1);
-        u8g2.setCursor(114, 16);
-        u8g2.print((char)176);
-        u8g2.print("C");
-        u8g2.setCursor(35, 26);
-        u8g2.print(langstring_set_temp);
-        u8g2.setCursor(84, 26);
-        u8g2.print(setpoint, 1);
-        u8g2.setCursor(114, 26);
-        u8g2.print((char)176);
-        u8g2.print("C");
+    u8g2.setCursor(35, 16);
+    u8g2.print(langstring_current_temp);
+    u8g2.setCursor(84, 16);
+    u8g2.print(temperature, 1);
+    u8g2.setCursor(114, 16);
+    u8g2.print((char)176);
+    u8g2.print("C");
+    u8g2.setCursor(35, 26);
+    u8g2.print(langstring_set_temp);
+    u8g2.setCursor(84, 26);
+    u8g2.print(setpoint, 1);
+    u8g2.setCursor(114, 26);
+    u8g2.print((char)176);
+    u8g2.print("C");
 
-        displayThermometerOutline(4, 62);
+    displayThermometerOutline(4, 62);
 
-        // Draw current temp in thermometer
-        if (fabs(temperature - setpoint) < 0.3) {
-            if (isrCounter < 500) {
-                drawTemperaturebar(8, 50, 30);
-            }
-        }
-        else {
+    // Draw current temp in thermometer
+    if (fabs(temperature - setpoint) < 0.3) {
+        if (isrCounter < 500) {
             drawTemperaturebar(8, 50, 30);
         }
-
-        // Brew time
-        u8g2.setCursor(35, 36);
-
-        // Shot timer shown if machine is brewing and after the brew
-        if (machineState == kBrew || machineState == kShotTimerAfterBrew) {
-            u8g2.print(langstring_brew);
-            u8g2.setCursor(84, 36);
-            u8g2.print(timeBrewed / 1000, 0);
-            u8g2.print("/");
-
-            if (BREWCONTROL_TYPE == 0) {
-                u8g2.print(brewtimesoftware, 0);
-            }
-            else {
-                u8g2.print(totalBrewTime / 1000, 1);
-            }
-        }
-
-        // PID values over heat bar
-        u8g2.setCursor(38, 47);
-
-        u8g2.print(bPID.GetKp(), 0);
-        u8g2.print("|");
-
-        if (bPID.GetKi() != 0) {
-            u8g2.print(bPID.GetKp() / bPID.GetKi(), 0);
-        }
-        else {
-            u8g2.print("0");
-        }
-
-        u8g2.print("|");
-        u8g2.print(bPID.GetKd() / bPID.GetKp(), 0);
-        u8g2.setCursor(96, 47);
-
-        if (pidOutput < 99) {
-            u8g2.print(pidOutput / 10, 1);
-        }
-        else {
-            u8g2.print(pidOutput / 10, 0);
-        }
-
-        u8g2.print("%");
-
-        // Show heater output in %
-        displayProgressbar(pidOutput / 10, 30, 60, 98);
-
-        u8g2.sendBuffer();
     }
+    else {
+        drawTemperaturebar(8, 50, 30);
+    }
+
+    // Brew time
+    u8g2.setCursor(35, 36);
+
+    // Shot timer shown if machine is brewing and after the brew
+    if (machineState == kBrew || machineState == kShotTimerAfterBrew) {
+        u8g2.print(langstring_brew);
+        u8g2.setCursor(84, 36);
+        u8g2.print(timeBrewed / 1000, 0);
+        u8g2.print("/");
+
+        if (BREWCONTROL_TYPE == 0) {
+            u8g2.print(brewtimesoftware, 0);
+        }
+        else {
+            u8g2.print(totalBrewTime / 1000, 1);
+        }
+    }
+
+    // PID values over heat bar
+    u8g2.setCursor(38, 47);
+
+    u8g2.print(bPID.GetKp(), 0);
+    u8g2.print("|");
+
+    if (bPID.GetKi() != 0) {
+        u8g2.print(bPID.GetKp() / bPID.GetKi(), 0);
+    }
+    else {
+        u8g2.print("0");
+    }
+
+    u8g2.print("|");
+    u8g2.print(bPID.GetKd() / bPID.GetKp(), 0);
+    u8g2.setCursor(96, 47);
+
+    if (pidOutput < 99) {
+        u8g2.print(pidOutput / 10, 1);
+    }
+    else {
+        u8g2.print(pidOutput / 10, 0);
+    }
+
+    u8g2.print("%");
+
+    // Show heater output in %
+    displayProgressbar(pidOutput / 10, 30, 60, 98);
+
+    u8g2.sendBuffer();
 }

--- a/src/display/displayTemplateStandard.h
+++ b/src/display/displayTemplateStandard.h
@@ -5,15 +5,19 @@
  *
  */
 
-#pragma once
+#include "displayCommon.h"
 
 /**
  * @brief Send data to display
  */
 void printScreen() {
-    if (((machineState == kPidNormal || machineState == kBrewDetectionTrailing) || ((machineState == kBrew || machineState == kShotTimerAfterBrew) && FEATURE_SHOTTIMER == 0) || // shottimer == 0, auch Bezug anzeigen
-         machineState == kCoolDown || (machineState == kPidNormal && (setpoint - temperature) > 5. && FEATURE_HEATINGLOGO == 0) || ((machineState == kPidDisabled) && FEATURE_PIDOFF_LOGO == 0)) &&
-        (brewSwitchState != kBrewSwitchFlushOff)) {
+
+    // Print the machine state
+    auto display_updated = displayMachineState();
+
+    // If no specific machine state was printed, print default:
+    if (!display_updated) {
+
         u8g2.clearBuffer();
         u8g2.setFont(u8g2_font_profont11_tf); // set font
 

--- a/src/display/displayTemplateTempOnly.h
+++ b/src/display/displayTemplateTempOnly.h
@@ -11,34 +11,23 @@
 int blinkingtemp = 1;           // 0: blinking near setpoint, 1: blinking far away from setpoint
 float blinkingtempoffset = 0.3; // offset for blinking
 
+#include "displayCommon.h"
+
 /**
  * @brief Send data to display
  */
 void printScreen() {
-    if (((machineState == kPidNormal || machineState == kBrewDetectionTrailing) || ((machineState == kBrew || machineState == kShotTimerAfterBrew) && FEATURE_SHOTTIMER == 0) || // shottimer == 0, auch Bezug anzeigen
-         machineState == kCoolDown || (machineState == kPidNormal && (setpoint - temperature) > 5. && FEATURE_HEATINGLOGO == 0) || ((machineState == kPidDisabled) && FEATURE_PIDOFF_LOGO == 0)) &&
-        (brewSwitchState != kBrewSwitchFlushOff)) {
-        if (!sensorError) {
-            u8g2.clearBuffer();
 
-            // draw (blinking) temp
-            if (((fabs(temperature - setpoint) < blinkingtempoffset && blinkingtemp == 0) || (fabs(temperature - setpoint) >= blinkingtempoffset && blinkingtemp == 1)) && !FEATURE_STATUS_LED) {
-                if (isrCounter < 500) {
-                    if (temperature < 99.999) {
-                        u8g2.setCursor(8, 22);
-                        u8g2.setFont(u8g2_font_fub35_tf);
-                        u8g2.print(temperature, 1);
-                        u8g2.drawCircle(116, 27, 4);
-                    }
-                    else {
-                        u8g2.setCursor(24, 22);
-                        u8g2.setFont(u8g2_font_fub35_tf);
-                        u8g2.print(temperature, 0);
-                        u8g2.drawCircle(116, 27, 4);
-                    }
-                }
-            }
-            else {
+    // Print the machine state
+    auto display_updated = displayMachineState();
+
+    // If no specific machine state was printed, print default:
+    if (!display_updated) {
+        u8g2.clearBuffer();
+
+        // draw (blinking) temp
+        if (((fabs(temperature - setpoint) < blinkingtempoffset && blinkingtemp == 0) || (fabs(temperature - setpoint) >= blinkingtempoffset && blinkingtemp == 1)) && !FEATURE_STATUS_LED) {
+            if (isrCounter < 500) {
                 if (temperature < 99.999) {
                     u8g2.setCursor(8, 22);
                     u8g2.setFont(u8g2_font_fub35_tf);
@@ -51,6 +40,20 @@ void printScreen() {
                     u8g2.print(temperature, 0);
                     u8g2.drawCircle(116, 27, 4);
                 }
+            }
+        }
+        else {
+            if (temperature < 99.999) {
+                u8g2.setCursor(8, 22);
+                u8g2.setFont(u8g2_font_fub35_tf);
+                u8g2.print(temperature, 1);
+                u8g2.drawCircle(116, 27, 4);
+            }
+            else {
+                u8g2.setCursor(24, 22);
+                u8g2.setFont(u8g2_font_fub35_tf);
+                u8g2.print(temperature, 0);
+                u8g2.drawCircle(116, 27, 4);
             }
         }
 

--- a/src/display/displayTemplateTempOnly.h
+++ b/src/display/displayTemplateTempOnly.h
@@ -18,31 +18,24 @@ float blinkingtempoffset = 0.3; // offset for blinking
  */
 void printScreen() {
 
+    // Show shot timer:
+    if (displayShottimer()) {
+        // Display was updated, end here
+        return;
+    }
+
     // Print the machine state
-    auto display_updated = displayMachineState();
+    if (displayMachineState()) {
+        // Display was updated, end here
+        return;
+    }
 
     // If no specific machine state was printed, print default:
-    if (!display_updated) {
-        u8g2.clearBuffer();
+    u8g2.clearBuffer();
 
-        // draw (blinking) temp
-        if (((fabs(temperature - setpoint) < blinkingtempoffset && blinkingtemp == 0) || (fabs(temperature - setpoint) >= blinkingtempoffset && blinkingtemp == 1)) && !FEATURE_STATUS_LED) {
-            if (isrCounter < 500) {
-                if (temperature < 99.999) {
-                    u8g2.setCursor(8, 22);
-                    u8g2.setFont(u8g2_font_fub35_tf);
-                    u8g2.print(temperature, 1);
-                    u8g2.drawCircle(116, 27, 4);
-                }
-                else {
-                    u8g2.setCursor(24, 22);
-                    u8g2.setFont(u8g2_font_fub35_tf);
-                    u8g2.print(temperature, 0);
-                    u8g2.drawCircle(116, 27, 4);
-                }
-            }
-        }
-        else {
+    // draw (blinking) temp
+    if (((fabs(temperature - setpoint) < blinkingtempoffset && blinkingtemp == 0) || (fabs(temperature - setpoint) >= blinkingtempoffset && blinkingtemp == 1)) && !FEATURE_STATUS_LED) {
+        if (isrCounter < 500) {
             if (temperature < 99.999) {
                 u8g2.setCursor(8, 22);
                 u8g2.setFont(u8g2_font_fub35_tf);
@@ -56,9 +49,23 @@ void printScreen() {
                 u8g2.drawCircle(116, 27, 4);
             }
         }
-
-        displayStatusbar();
-
-        u8g2.sendBuffer();
     }
+    else {
+        if (temperature < 99.999) {
+            u8g2.setCursor(8, 22);
+            u8g2.setFont(u8g2_font_fub35_tf);
+            u8g2.print(temperature, 1);
+            u8g2.drawCircle(116, 27, 4);
+        }
+        else {
+            u8g2.setCursor(24, 22);
+            u8g2.setFont(u8g2_font_fub35_tf);
+            u8g2.print(temperature, 0);
+            u8g2.drawCircle(116, 27, 4);
+        }
+    }
+
+    displayStatusbar();
+
+    u8g2.sendBuffer();
 }

--- a/src/display/displayTemplateUpright.h
+++ b/src/display/displayTemplateUpright.h
@@ -11,6 +11,13 @@
  * @brief Send data to display
  */
 void printScreen() {
+    // Show shot timer:
+    if (displayShottimer()) {
+        // Display was updated, end here
+        return;
+    }
+
+    // If no specific machine state was printed, print default:
     if (((machineState == kPidNormal || machineState == kBrewDetectionTrailing) || ((machineState == kBrew || machineState == kShotTimerAfterBrew) && FEATURE_SHOTTIMER == 0) || // shottimer == 0, auch Bezug anzeigen
          machineState == kCoolDown || (machineState == kPidNormal && (setpoint - temperature) > 5. && FEATURE_HEATINGLOGO == 0) || ((machineState == kPidDisabled) && FEATURE_PIDOFF_LOGO == 0)) &&
         (brewSwitchState != kBrewSwitchFlushOff)) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2052,10 +2052,7 @@ void looppid() {
 
     if (currentMillisDisplay - previousMillisDisplay >= intervalDisplay) {
         previousMillisDisplay = currentMillisDisplay;
-#if DISPLAYTEMPLATE < 20 // not using vertical template
-        displayMachineState();
-#endif
-        printScreen();   // refresh display
+        printScreen(); // refresh display
     }
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -419,7 +419,7 @@ U8G2_SH1106_128X64_NONAME_F_4W_HW_SPI u8g2(U8G2_R0, OLED_CS, OLED_DC, /* reset=*
 
 // Update for Display
 unsigned long previousMillisDisplay; // initialisation at the end of init()
-const unsigned long intervalDisplay = 500;
+const unsigned long intervalDisplay = 100;
 
 // Horizontal or vertical display
 #if (OLED_DISPLAY != 0)
@@ -2045,10 +2045,6 @@ void looppid() {
     // Check if PID should run or not. If not, set to manual and force output to zero
 #if OLED_DISPLAY != 0
     unsigned long currentMillisDisplay = millis();
-
-    if (currentMillisDisplay - previousMillisDisplay >= 100) {
-        displayShottimer();
-    }
 
     if (currentMillisDisplay - previousMillisDisplay >= intervalDisplay) {
         previousMillisDisplay = currentMillisDisplay;


### PR DESCRIPTION
This PR starts simplifying (with a first baby step) the display code. Main problem:

* We first call `displayMachineState()` (unless in rotated display mode)
* Then we call `printscreen()`.
* In order for the latter not to overwrite the previously printed screen, there is an enormous `if` clause which attempts to be the inverse of all `if`s in `displayMachineState()`.

This leads to obvious problems as soon as we change sth somewhere. This PR essentially does one simple thing:

* `displayMachineState` returns a boolean telling us whether it *actually* updated things
* We call this directly from `printscreen()` and only proceed overwriting if it returned `false` (screen not updated)

This gets rid of the enormous and error-prone `if` as well as the use of `#ifdef` for the upright display - we just don't call the `displayMachineState` from its `printscreen()` method.

More to come on the display front, but merging this would be appreciated - #486 broke the display a little such that blinking temperature and heating are displayed alternating.