### PR TITLE
Improve Switch Classes

### DIFF
--- a/src/hardware/IOSwitch.cpp
+++ b/src/hardware/IOSwitch.cpp
@@ -8,17 +8,7 @@
 #include "GPIOPin.h"
 
 IOSwitch::IOSwitch(GPIOPin& gpioInstance, Type type, Mode mode) :
-    gpio(gpioInstance),
-    switchType(type),
-    switchMode(mode),
-    debounceDelay(20),
-    longPressDuration(500),
-    lastState(LOW),
-    currentState(LOW),
-    lastDebounceTime(0),
-    lastStateChangeTime(0),
-    pressStartTime(0),
-    longPressTriggered(false) {
+    Switch(type, mode), gpio(gpioInstance), debounceDelay(20), longPressDuration(500), lastState(LOW), currentState(LOW), lastDebounceTime(0), lastStateChangeTime(0), pressStartTime(0), longPressTriggered(false) {
 }
 
 bool IOSwitch::isPressed() {
@@ -30,8 +20,8 @@ bool IOSwitch::isPressed() {
     }
 
     if ((currentMillis - lastDebounceTime) > debounceDelay) {
-        if ((reading ^ switchMode) != currentState) {
-            currentState = reading ^ switchMode;
+        if ((reading ^ mode_) != currentState) {
+            currentState = reading ^ mode_;
 
             if (currentState == LOW) {
                 lastStateChangeTime = currentMillis;
@@ -45,7 +35,7 @@ bool IOSwitch::isPressed() {
         pressStartTime = millis();
     }
 
-    if (switchType == MOMENTARY) {
+    if (type_ == MOMENTARY) {
         if (currentState == HIGH && (pressStartTime + longPressDuration) <= currentMillis) {
             longPressTriggered = true;
         }
@@ -58,10 +48,10 @@ bool IOSwitch::isPressed() {
 }
 
 bool IOSwitch::longPressDetected() {
-    if (switchType == TOGGLE) {
+    if (type_ == TOGGLE) {
         return false;
     }
-    else if (switchType == MOMENTARY) {
+    else if (type_ == MOMENTARY) {
         return longPressTriggered;
     }
 
@@ -70,12 +60,4 @@ bool IOSwitch::longPressDetected() {
 
 GPIOPin& IOSwitch::getGPIOInstance() {
     return gpio;
-}
-
-void IOSwitch::setType(Type type) {
-    switchType = type;
-}
-
-void IOSwitch::setMode(Mode mode) {
-    switchMode = mode;
 }

--- a/src/hardware/IOSwitch.cpp
+++ b/src/hardware/IOSwitch.cpp
@@ -7,8 +7,8 @@
 #include "IOSwitch.h"
 #include "GPIOPin.h"
 
-IOSwitch::IOSwitch(GPIOPin& gpioInstance, Type type, Mode mode) :
-    Switch(type, mode), gpio(gpioInstance), debounceDelay(20), longPressDuration(500), lastState(LOW), currentState(LOW), lastDebounceTime(0), lastStateChangeTime(0), pressStartTime(0), longPressTriggered(false) {
+IOSwitch::IOSwitch(int pinNumber, GPIOPin::Type pinType, Type switchType, Mode mode) :
+    Switch(switchType, mode), gpio(pinNumber, pinType) {
 }
 
 bool IOSwitch::isPressed() {
@@ -56,8 +56,4 @@ bool IOSwitch::longPressDetected() {
     }
 
     return false;
-}
-
-GPIOPin& IOSwitch::getGPIOInstance() {
-    return gpio;
 }

--- a/src/hardware/IOSwitch.h
+++ b/src/hardware/IOSwitch.h
@@ -18,14 +18,10 @@ class IOSwitch : public Switch {
 
         bool isPressed() override;
         bool longPressDetected() override;
-        void setType(Type type);
-        void setMode(Mode mode);
         GPIOPin& getGPIOInstance();
 
     private:
         GPIOPin& gpio;
-        Type switchType;
-        Mode switchMode;
         uint8_t lastState;
         uint8_t currentState;
         unsigned long lastDebounceTime;

--- a/src/hardware/IOSwitch.h
+++ b/src/hardware/IOSwitch.h
@@ -8,27 +8,50 @@
 
 #include <cstdint>
 
+#include "GPIOPin.h"
 #include "Switch.h"
-
-class GPIOPin;
 
 class IOSwitch : public Switch {
     public:
-        IOSwitch(GPIOPin& gpioInstance, Type type = MOMENTARY, Mode mode = NORMALLY_OPEN);
+        /**
+         * @brief I/O Switch connected to a GPIO pin
+         * @details This class represents a switch which is connected to a GPIO pin of the controller. It holds its own
+         *          instance of the GPIO pin.
+         *
+         * @param pinNumber GPIO pin number
+         * @param pinType GPIO pin type
+         * @param switchType Type of the switch
+         * @param mode Operation mode of the switch
+         */
+        IOSwitch(int pinNumber, GPIOPin::Type pinType, Type switchType = MOMENTARY, Mode mode = NORMALLY_OPEN);
 
+        /**
+         * @brief Switch reading (pressed, not pressed)
+         * @details This function reads the connected GPIO pin and returns a debounced reading of the witch
+         * @return True of activated, false otherwise
+         */
         bool isPressed() override;
+
+        /**
+         * @brief Check if a long press of the momentary switch has been detected
+         * @details Always returns false for toggle switches
+         * @return True if the momentary switch is held down, false otherwise
+         */
         bool longPressDetected() override;
-        GPIOPin& getGPIOInstance();
 
     private:
-        GPIOPin& gpio;
-        uint8_t lastState;
-        uint8_t currentState;
-        unsigned long lastDebounceTime;
-        unsigned long lastStateChangeTime;
-        unsigned long pressStartTime;
-        bool longPressTriggered;
+        // Pin to operate on:
+        GPIOPin gpio;
 
-        const unsigned long debounceDelay;
-        const unsigned long longPressDuration;
+        // Switch state
+        uint8_t lastState{LOW};
+        uint8_t currentState{LOW};
+
+        // Debouncing and long-press detection
+        unsigned long lastStateChangeTime{0};
+        unsigned long pressStartTime{0};
+        bool longPressTriggered{false};
+        unsigned long lastDebounceTime{0};
+        const unsigned long debounceDelay{20};
+        const unsigned long longPressDuration{500};
 };

--- a/src/hardware/Switch.h
+++ b/src/hardware/Switch.h
@@ -22,14 +22,32 @@ class Switch {
             TOGGLE
         };
 
+        /**
+         * @enum Mode
+         * @brief Switch mode, normally-open or normally-closed
+         * @details There are two types of switches, the ones that are closed by default (normally-closed, NC) or open
+         *          (normally-open, NO)
+         */
         enum Mode {
             NORMALLY_OPEN,
             NORMALLY_CLOSED
         };
 
+        /**
+         * @brief Constructor for a new switch
+         *
+         * @param type Switch type
+         * @param mode Operation mode
+         */
+        Switch(Type type, Mode mode) :
+            type_(type), mode_(mode){};
+        Switch() = delete;
+        virtual ~Switch() = default;
+
         virtual bool isPressed() = 0;
         virtual bool longPressDetected() = 0;
-        virtual void setType(Type type) = 0;
-        virtual ~Switch() {
-        }
+
+    protected:
+        Type type_;
+        Mode mode_;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -169,10 +169,6 @@ Relay pumpRelay(pumpRelayPin, PUMP_VALVE_SSR_TYPE);
 GPIOPin valveRelayPin(PIN_VALVE, GPIOPin::OUT);
 Relay valveRelay(valveRelayPin, PUMP_VALVE_SSR_TYPE);
 
-GPIOPin* powerSwitchPin;
-GPIOPin* brewSwitchPin;
-GPIOPin* steamSwitchPin;
-
 Switch* powerSwitch;
 Switch* brewSwitch;
 Switch* steamSwitch;
@@ -1799,13 +1795,11 @@ void setup() {
     pumpRelay.off();
 
     if (FEATURE_POWERSWITCH) {
-        powerSwitchPin = new GPIOPin(PIN_POWERSWITCH, GPIOPin::IN_HARDWARE);
-        powerSwitch = new IOSwitch(*powerSwitchPin, POWERSWITCH_TYPE, POWERSWITCH_MODE);
+        powerSwitch = new IOSwitch(PIN_POWERSWITCH, GPIOPin::IN_HARDWARE, POWERSWITCH_TYPE, POWERSWITCH_MODE);
     }
 
     if (FEATURE_STEAMSWITCH) {
-        steamSwitchPin = new GPIOPin(PIN_STEAMSWITCH, GPIOPin::IN_HARDWARE);
-        steamSwitch = new IOSwitch(*steamSwitchPin, STEAMSWITCH_TYPE, STEAMSWITCH_MODE);
+        steamSwitch = new IOSwitch(PIN_STEAMSWITCH, GPIOPin::IN_HARDWARE, STEAMSWITCH_TYPE, STEAMSWITCH_MODE);
     }
 
     // IF optocoupler selected
@@ -1818,8 +1812,7 @@ void setup() {
         }
     }
     else if (FEATURE_BREWSWITCH) {
-        brewSwitchPin = new GPIOPin(PIN_BREWSWITCH, GPIOPin::IN_HARDWARE);
-        brewSwitch = new IOSwitch(*brewSwitchPin, BREWSWITCH_TYPE, BREWSWITCH_MODE);
+        brewSwitch = new IOSwitch(PIN_BREWSWITCH, GPIOPin::IN_HARDWARE, BREWSWITCH_TYPE, BREWSWITCH_MODE);
     }
 
     if (LED_TYPE == LED::STANDARD) {


### PR DESCRIPTION
This makes a few changes to the switch classes:

* `Switch` now holds its own `Type` and `Mode`
* `IOSwitch` now holds its private `GPIOPin` and also constructs it

This simplifies the overall code, encapsulates GPIO pins where they belong and removes global pointer objects.