### PR TITLE
Fix Shottimer Scale and inclusion of BREWCONTROL_TYPE 2 in 1, with choice of brew-type via parameter in Website

### DIFF
--- a/data/js/app.js
+++ b/data/js/app.js
@@ -76,8 +76,9 @@ const vueApp = Vue.createApp({
                 0: 'PID Parameters',
                 1: 'Temperature and Preinfusion',
                 2: 'Brew Detection and Brew PID Parameters',
-                3: 'Scale Parameters',
-                4: 'Power Settings'
+                3: 'Brew Control',
+                4: 'Scale Parameters',
+                5: 'Power Settings'
             }
             
             return sectionNames[sectionId]

--- a/src/defaults.h
+++ b/src/defaults.h
@@ -73,7 +73,7 @@ int writeSysParamsToStorage(void);
 #define BREW_TEMP_OFFSET_MAX   20
 #define BREW_TEMP_TIME_MIN     1
 #define BREW_TEMP_TIME_MAX     180
-#define BREW_TIME_MIN          1
+#define BREW_TIME_MIN          0
 #define BREW_TIME_MAX          180
 #define BREW_PID_DELAY_MIN     0
 #define BREW_PID_DELAY_MAX     60

--- a/src/display/displayCommon.h
+++ b/src/display/displayCommon.h
@@ -241,7 +241,7 @@ bool displayShottimer() {
         return false;
     }
 
-    if ((machineState == kBrew || brewSwitchState == kBrewSwitchFlushOff) && SHOTTIMER_TYPE == 1) {
+    if (machineState == kBrew || brewSwitchState == kBrewSwitchFlushOff) {
         u8g2.clearBuffer();
 
         if (brewSwitchState != kBrewSwitchFlushOff) {
@@ -251,7 +251,18 @@ bool displayShottimer() {
             u8g2.drawXBMP(0, 12, Manual_Flush_Logo_width, Manual_Flush_Logo_height, Manual_Flush_Logo);
         }
 
+#if (FEATURE_SCALE == 1)
+        u8g2.setFont(u8g2_font_profont22_tf);
+        u8g2.setCursor(64, 15);
+        u8g2.print(timeBrewed / 1000, 1);
+        u8g2.print("s");
+        u8g2.setCursor(64, 38);
+        u8g2.print(weightBrew, 1);
+        u8g2.print("g");
+        u8g2.setFont(u8g2_font_profont11_tf);
+#else
         displayBrewtime(48, 25, timeBrewed);
+#endif
 
         displayWaterIcon(119, 1);
         u8g2.sendBuffer();
@@ -262,39 +273,11 @@ bool displayShottimer() {
      * nothing should be done, otherwise wrong time is displayed
      * because the switch is pressed later than totalBrewTime
      */
-    else if ((machineState == kShotTimerAfterBrew && brewSwitchState != kBrewSwitchFlushOff) && SHOTTIMER_TYPE == 1) {
+    else if (machineState == kShotTimerAfterBrew && brewSwitchState != kBrewSwitchFlushOff) {
         u8g2.clearBuffer();
         u8g2.drawXBMP(-1, 11, Brew_Cup_Logo_width, Brew_Cup_Logo_height, Brew_Cup_Logo);
 
-        displayBrewtime(48, 25, lastBrewTime);
-
-        displayWaterIcon(119, 1);
-        u8g2.sendBuffer();
-        return true;
-    }
-
-#if FEATURE_SCALE == 1
-    else if ((machineState == kBrew) && SHOTTIMER_TYPE == 2) {
-        u8g2.clearBuffer();
-
-        // temp icon
-        u8g2.drawXBMP(-1, 11, Brew_Cup_Logo_width, Brew_Cup_Logo_height, Brew_Cup_Logo);
-        u8g2.setFont(u8g2_font_profont22_tf);
-        u8g2.setCursor(64, 15);
-        u8g2.print(timeBrewed / 1000, 1);
-        u8g2.print("s");
-        u8g2.setCursor(64, 38);
-        u8g2.print(weightBrew, 1);
-        u8g2.print("g");
-        u8g2.setFont(u8g2_font_profont11_tf);
-        displayWaterIcon(119, 1);
-        u8g2.sendBuffer();
-        return true;
-    }
-
-    else if (((machineState == kShotTimerAfterBrew) && SHOTTIMER_TYPE == 2)) {
-        u8g2.clearBuffer();
-        u8g2.drawXBMP(-1, 11, Brew_Cup_Logo_width, Brew_Cup_Logo_height, Brew_Cup_Logo);
+#if (FEATURE_SCALE == 1)
         u8g2.setFont(u8g2_font_profont22_tf);
         u8g2.setCursor(64, 15);
         u8g2.print(lastBrewTime / 1000, 1);
@@ -303,11 +286,14 @@ bool displayShottimer() {
         u8g2.print(weightBrew, 1);
         u8g2.print("g");
         u8g2.setFont(u8g2_font_profont11_tf);
+#else
+        displayBrewtime(48, 25, lastBrewTime);
+#endif
+
         displayWaterIcon(119, 1);
         u8g2.sendBuffer();
         return true;
     }
-#endif
     return false;
 }
 

--- a/src/display/displayRotateUpright.h
+++ b/src/display/displayRotateUpright.h
@@ -88,7 +88,7 @@ void displayEmergencyStop(void) {
  * @brief display shot timer
  */
 bool displayShottimer() {
-    if (((timeBrewed > 0 && BREWCONTROL_TYPE == 0) || (BREWCONTROL_TYPE > 0 && currBrewState > kBrewIdle && currBrewState <= kBrewFinished)) && FEATURE_SHOTTIMER == 1 && SHOTTIMER_TYPE == 1) {
+    if (((timeBrewed > 0 && FEATURE_BREWCONTROL == 0) || (FEATURE_BREWCONTROL > 0 && currBrewState > kBrewIdle && currBrewState <= kBrewFinished)) && FEATURE_SHOTTIMER == 1) {
         u8g2.clearBuffer();
 
         // draw temp icon
@@ -100,8 +100,8 @@ bool displayShottimer() {
         u8g2.sendBuffer();
         return true;
     }
-    else if (FEATURE_SHOTTIMER == 1 && SHOTTIMER_TYPE == 1 && millis() >= lastBrewTimeMillis && // directly after creating lastbrewTimeMillis (happens when turning off the brew switch, case 43 in the code) should be started
-             lastBrewTimeMillis + SHOTTIMERDISPLAYDELAY >= millis() &&                          // should run until millis() has caught up with SHOTTIMERDISPLAYDELAY, this can be used to control the display duration
+    else if (FEATURE_SHOTTIMER == 1 && millis() >= lastBrewTimeMillis && // directly after creating lastbrewTimeMillis (happens when turning off the brew switch, case 43 in the code) should be started
+             lastBrewTimeMillis + SHOTTIMERDISPLAYDELAY >= millis() &&   // should run until millis() has caught up with SHOTTIMERDISPLAYDELAY, this can be used to control the display duration
              lastBrewTimeMillis < totalBrewTime) // if the totalBrewTime is reached automatically, nothing should be done, otherwise wrong time will be displayed because switch is pressed later than totalBrewTime
     {
         u8g2.clearBuffer();
@@ -114,5 +114,5 @@ bool displayShottimer() {
         return true;
     }
 
-    return false
+    return false;
 }

--- a/src/display/displayTemplateMinimal.h
+++ b/src/display/displayTemplateMinimal.h
@@ -91,7 +91,7 @@ void printScreen() {
         u8g2.print(timeBrewed / 1000, 0);
         u8g2.print("/");
 
-        if (BREWCONTROL_TYPE == 0) {
+        if (FEATURE_BREWCONTROL == 0) {
             u8g2.print(brewtimesoftware, 0);
         }
         else {

--- a/src/display/displayTemplateScale.h
+++ b/src/display/displayTemplateScale.h
@@ -65,8 +65,11 @@ void printScreen() {
             u8g2.print(weight, 0);
         }
 
-        u8g2.print("/");
-        u8g2.print(weightSetpoint, 0);
+        if (weightSetpoint > 0) {
+            u8g2.print("/");
+            u8g2.print(weightSetpoint, 0);
+        }
+
         u8g2.print(" (");
         u8g2.print(weightBrew, 1);
         u8g2.print(")");
@@ -76,13 +79,20 @@ void printScreen() {
     u8g2.setCursor(32, 36);
     u8g2.print("t: ");
     u8g2.print(timeBrewed / 1000, 0);
-    u8g2.print("/");
 
-    if (BREWCONTROL_TYPE == 0) {
+    if (FEATURE_BREWCONTROL == 0) {
+        u8g2.print("/");
         u8g2.print(brewtimesoftware, 0);
     }
     else {
-        u8g2.print(totalBrewTime / 1000, 1);
+        if (brewTime > 0) {
+            u8g2.print("/");
+            u8g2.print(totalBrewTime / 1000, 0);
+        }
+
+        u8g2.print(" (");
+        u8g2.print(lastBrewTime / 1000, 1);
+        u8g2.print(")");
     }
 
 #if (FEATURE_PRESSURESENSOR == 1)

--- a/src/display/displayTemplateStandard.h
+++ b/src/display/displayTemplateStandard.h
@@ -69,7 +69,7 @@ void printScreen() {
         u8g2.print(timeBrewed / 1000, 0);
         u8g2.print("/");
 
-        if (BREWCONTROL_TYPE == 0) {
+        if (FEATURE_BREWCONTROL == 0) {
             u8g2.print(brewtimesoftware, 0);
         }
         else {

--- a/src/display/displayTemplateUpright.h
+++ b/src/display/displayTemplateUpright.h
@@ -21,7 +21,7 @@ void printScreen() {
     if (((machineState == kPidNormal || machineState == kBrewDetectionTrailing) || ((machineState == kBrew || machineState == kShotTimerAfterBrew) && FEATURE_SHOTTIMER == 0) || // shottimer == 0, auch Bezug anzeigen
          (machineState == kPidNormal && (setpoint - temperature) > 5. && FEATURE_HEATINGLOGO == 0) || ((machineState == kPidDisabled) && FEATURE_PIDOFF_LOGO == 0)) &&
         (brewSwitchState != kBrewSwitchFlushOff)) {
-        if (!sensorError) {
+        if (!tempSensor->hasError()) {
             u8g2.clearBuffer();
             u8g2.setCursor(1, 14);
             u8g2.print(langstring_current_temp_rot_ur);
@@ -103,7 +103,7 @@ void printScreen() {
             u8g2.print(timeBrewed / 1000, 0);
             u8g2.print("/");
 
-            if (BREWCONTROL_TYPE == 0) {
+            if (FEATURE_BREWCONTROL == 0) {
                 u8g2.print(brewtimesoftware, 0);     // deaktivieren wenn Preinfusion ( // voransetzen )
             }
             else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1301,7 +1301,7 @@ void setup() {
 
     editableVars["BREW_TIME"] = {.displayName = F("Brew Time (s)"),
                                  .hasHelpText = true,
-                                 .helpText = F("Stop brew after this time --> 0=Deactivated"),
+                                 .helpText = F("Stop brew after this time. Set to 0 to deactivate brew-by-time-feature."),
                                  .type = kDouble,
                                  .section = sBrewSection,
                                  .position = 14,
@@ -1334,7 +1334,7 @@ void setup() {
 
     editableVars["SCALE_WEIGHTSETPOINT"] = {.displayName = F("Brew weight setpoint (g)"),
                                             .hasHelpText = true,
-                                            .helpText = F("Brew until this weight has been measured. --> 0=Deactivated"),
+                                            .helpText = F("Brew is running until this weight has been measured. Set to 0 to deactivate brew-by-weight-feature."),
                                             .type = kDouble,
                                             .section = sBrewSection,
                                             .position = 17,

--- a/src/scaleHandler.h
+++ b/src/scaleHandler.h
@@ -186,6 +186,9 @@ void shottimerscale() {
                     weightPreBrew = weight;
                     shottimerCounter = 20;
                 }
+                else if (timeBrewed > 0) {
+                    weightBrew = 0;
+                }
             }
 
             break;

--- a/src/userConfig_sample.h
+++ b/src/userConfig_sample.h
@@ -52,7 +52,7 @@ enum MACHINE {
 // PID & Hardware
 #define FEATURE_BREWCONTROL   0                       // 0 = deactivated, 1 = activated
 #define FEATURE_BREWDETECTION 1                       // 0 = deactivated, 1 = activated
-#define BREWDETECTION_TYPE    1                       // 1 = Software (FEATURE_BREWCONTROL 0), 2 = Hardware FEATURE_BREWCONTROL 1, 3 = optocoupler for FEATURE_BREWCONTROL 0
+#define BREWDETECTION_TYPE    1                       // 1 = Software (FEATURE_BREWCONTROL 0), 2 = Hardware (FEATURE_BREWCONTROL 1), 3 = Optocoupler (FEATURE_BREWCONTROL 0)
 #define FEATURE_POWERSWITCH   0                       // 0 = deactivated, 1 = activated
 #define POWERSWITCH_TYPE      Switch::TOGGLE          // Switch::TOGGLE or Switch::MOMENTARY (trigger)
 #define POWERSWITCH_MODE      Switch::NORMALLY_OPEN   // Switch::NORMALLY_OPEN or Switch::NORMALLY_CLOSED

--- a/src/userConfig_sample.h
+++ b/src/userConfig_sample.h
@@ -35,8 +35,7 @@ enum MACHINE {
 #define DISPLAYROTATE         U8G2_R0 // rotate display clockwise: U8G2_R0 = no rotation; U8G2_R1 = 90°; U8G2_R2 = 180°; U8G2_R3 = 270°
 #define SCREEN_WIDTH          128     // OLED display width, in pixels
 #define SCREEN_HEIGHT         64      // OLED display height, in pixels
-#define FEATURE_SHOTTIMER     1       // 0 = deactivated, 1 = activated
-#define SHOTTIMER_TYPE        1       // 1 = timer 2 = timer with scale
+#define FEATURE_SHOTTIMER     1       // 0 = deactivated, 1 = activated (with weight if FEATURE_SCALE activated)
 #define FEATURE_HEATINGLOGO   1       // 0 = deactivated, 1 = activated
 #define FEATURE_PIDOFF_LOGO   1       // 0 = deactivated, 1 = activated
 #define SHOTTIMERDISPLAYDELAY 3000    // time in ms that shot timer will be shown after brew finished
@@ -51,9 +50,9 @@ enum MACHINE {
 #define WIFICONNECTIONDELAY 10000          // delay between reconnects in ms
 
 // PID & Hardware
-#define BREWCONTROL_TYPE      0                       // 0 = off (no brewing control), 1 = Brew by time (with preinfusion), 2 = Brew by weight (from scale)
+#define FEATURE_BREWCONTROL   0                       // 0 = deactivated, 1 = activated
 #define FEATURE_BREWDETECTION 1                       // 0 = deactivated, 1 = activated
-#define BREWDETECTION_TYPE    1                       // 1 = Software (BREWCONTROL_TYPE 0), 2 = Hardware BREWCONTROL_TYPE 1 or 2, 3 = optocoupler for BREWCONTROL_TYPE 0
+#define BREWDETECTION_TYPE    1                       // 1 = Software (FEATURE_BREWCONTROL 0), 2 = Hardware FEATURE_BREWCONTROL 1, 3 = optocoupler for FEATURE_BREWCONTROL 0
 #define FEATURE_POWERSWITCH   0                       // 0 = deactivated, 1 = activated
 #define POWERSWITCH_TYPE      Switch::TOGGLE          // Switch::TOGGLE or Switch::MOMENTARY (trigger)
 #define POWERSWITCH_MODE      Switch::NORMALLY_OPEN   // Switch::NORMALLY_OPEN or Switch::NORMALLY_CLOSED


### PR DESCRIPTION
brewHandler.h/userConfig_sample.h:
Removed the brew by weight as a separate type and included its functionality in brew by time for easier maintenance.

displayCommon.h:
Updated SHOTTIMER_TYPE 2 (With scale) to functionality already available at SHOTTIMER_TYPE 1