### PR TITLE
Hotfix: Fix PID Mode after Startup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-merge-conflict
       - id: check-yaml

--- a/src/hardware/Switch.h
+++ b/src/hardware/Switch.h
@@ -40,7 +40,7 @@ class Switch {
          * @param mode Operation mode
          */
         Switch(Type type, Mode mode) :
-            type_(type), mode_(mode){};
+            type_(type), mode_(mode) {};
         Switch() = delete;
         virtual ~Switch() = default;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2062,7 +2062,7 @@ void looppid() {
     }
     else { // no sensorerror, no pid off or no Emergency Stop
         if (bPID.GetMode() == 0) {
-            bPID.SetMode(0);
+            bPID.SetMode(1);
         }
     }
 

--- a/src/utils/Timer.h
+++ b/src/utils/Timer.h
@@ -12,7 +12,7 @@ class Timer {
     public:
         Timer() = delete;
         Timer(std::function<void()> func, unsigned long interval) :
-            callback_(func), interval_(interval){};
+            callback_(func), interval_(interval) {};
         void operator()();
 
     private:


### PR DESCRIPTION
This fixes a typo introduced in 51f8c5cdce2bc49a71333ef6827970490769f572