### PR TITLE
Rework Temperature & Error Handling

### DIFF
--- a/src/brewHandler.h
+++ b/src/brewHandler.h
@@ -247,7 +247,7 @@ void brew() {
         timeBrewed = currentMillisTemp - startingTime;
     }
 
-    if (currStateBrewSwitch == LOW && movingAverageInitialized) {
+    if (currStateBrewSwitch == LOW) {
         // check if brewswitch was turned off at least once, last time,
         brewSwitchWasOff = true;
     }

--- a/src/hardware/TempSensor.h
+++ b/src/hardware/TempSensor.h
@@ -6,15 +6,22 @@
 
 #pragma once
 
+#include <cmath>
+
+#include "Logger.h"
+
 class TempSensor {
     public:
         /**
          * @brief Returns the current temperature
-         * @details Requests sampling from attached sensor and returns reading. This method is purely virtual and must be
-         *          implemented by every child class.
+         * @details Requests sampling from attached sensor and returns reading.
          * @return Temperature in degrees Celsius
          */
-        virtual float getTemperatureCelsius() const = 0;
+        virtual float getTemperatureCelsius() {
+            auto temperature = sample_temperature();
+            last_temperature_ = temperature;
+            return temperature;
+        }
 
         /**
          * @brief Returns sampling interval for the sensor
@@ -32,4 +39,56 @@ class TempSensor {
          */
         virtual ~TempSensor() {
         }
+
+        /**
+         * @brief check sensor value.
+         * @return If < 0 or difference between old and new >25, then increase error.
+         *      If error is equal to maxErrorCounter, then set sensorError
+         */
+        bool check(float temperature, float offset) {
+            bool sensorOK = false;
+            bool badCondition = (temperature < 0 || temperature > 150 || std::fabs(temperature - last_temperature_) > (5 + offset));
+
+            if (badCondition && !error_) {
+                bad_readings_++;
+                sensorOK = false;
+
+                LOGF(WARNING, "temperature sensor reading: consec_errors = %i, temp_current = %.1f, temp_prev = %.1f", bad_readings_, temperature, last_temperature_);
+            }
+            else if (badCondition == false && sensorOK == false) {
+                bad_readings_ = 0;
+                sensorOK = true;
+            }
+
+            if (bad_readings_ >= max_bad_treadings_ && !error_) {
+                error_ = true;
+                LOGF(ERROR, "temperature sensor malfunction: temp_current = %.1f", temperature);
+            }
+            else if (bad_readings_ == 0 && error_) {
+                error_ = false;
+            }
+
+            return sensorOK;
+        }
+
+        bool hasError() {
+            return error_;
+        }
+
+    protected:
+        /**
+         * @brief Samples the current temperature from the sensor
+         * @details Requests sampling from attached sensor and returns reading. This method is purely virtual and must be
+         *          implemented by every child class.
+         * @return Temperature in degrees Celsius
+         */
+        virtual float sample_temperature() const = 0;
+
+    private:
+        float last_temperature_{};
+
+        int bad_readings_{0};
+        int max_bad_treadings_{10};
+
+        bool error_{false};
 };

--- a/src/hardware/TempSensor.h
+++ b/src/hardware/TempSensor.h
@@ -11,35 +11,36 @@
 #include <numeric>
 
 #include "Logger.h"
+#include "utils/Timer.h"
 
 class TempSensor {
     public:
+        /**
+         * @brief Abstract temperature sensor class
+         * @details This class controls a temperature sensor. It updates the value in regular intervals of 400ms, controlled
+         *          by a timer. The temperature sampling result is checked for errors and an internal error counter is kept
+         *          to detect consecutive reading errors
+         */
+        TempSensor() :
+            update_temperature(std::bind(&TempSensor::update_temperature_reading, this), 400) {
+        }
+
         /**
          * @brief Returns the current temperature
          * @details Requests sampling from attached sensor and returns reading.
          * @return Temperature in degrees Celsius
          */
-        virtual float getCurrentTemperature() {
-            auto temperature = sample_temperature();
-            last_temperature_ = temperature;
-            update_moving_average();
-            return temperature;
+        double getCurrentTemperature() {
+            // Trigger the timer to update the temperature:
+            update_temperature();
+            return last_temperature_;
         }
 
-        float getAverageTemperatureRate() {
+        double getAverageTemperatureRate() {
+            // Trigger the timer to update the temperature:
+            update_temperature();
             return average_temp_rate_;
         }
-
-        /**
-         * @brief Returns sampling interval for the sensor
-         * @details Returns a value to control how often the sensor is sampled. This is a static value, typically fixed for
-         *          a given sensor hardware type and is used to avoid polling the sensor too often without new readings
-         *          available.
-         * @return Sampling interval in milliseconds
-         */
-        virtual int getSamplingInterval() const {
-            return 400;
-        };
 
         /**
          * @brief Default destructor
@@ -47,36 +48,9 @@ class TempSensor {
         virtual ~TempSensor() = default;
 
         /**
-         * @brief check sensor value.
-         * @return If < 0 or difference between old and new >25, then increase error.
-         *      If error is equal to maxErrorCounter, then set sensorError
+         * @brief Returns error state of the temperature sensor
+         * @return true if the sensor is in error, false otherwise
          */
-        bool check(float temperature, float offset) {
-            bool sensorOK = false;
-            bool badCondition = (temperature < 0 || temperature > 150 || std::fabs(temperature - last_temperature_) > (5 + offset));
-
-            if (badCondition && !error_) {
-                bad_readings_++;
-                sensorOK = false;
-
-                LOGF(WARNING, "temperature sensor reading: consec_errors = %i, temp_current = %.1f, temp_prev = %.1f", bad_readings_, temperature, last_temperature_);
-            }
-            else if (badCondition == false && sensorOK == false) {
-                bad_readings_ = 0;
-                sensorOK = true;
-            }
-
-            if (bad_readings_ >= max_bad_treadings_ && !error_) {
-                error_ = true;
-                LOGF(ERROR, "temperature sensor malfunction: temp_current = %.1f", temperature);
-            }
-            else if (bad_readings_ == 0 && error_) {
-                error_ = false;
-            }
-
-            return sensorOK;
-        }
-
         bool hasError() {
             return error_;
         }
@@ -85,12 +59,44 @@ class TempSensor {
         /**
          * @brief Samples the current temperature from the sensor
          * @details Requests sampling from attached sensor and returns reading. This method is purely virtual and must be
-         *          implemented by every child class.
-         * @return Temperature in degrees Celsius
+         *          implemented by every child class. The argument is passed by reference and is updated if the return value
+         *          of the function is true.
+         * @return Boolean indicating whether the reading has been successful
          */
         virtual bool sample_temperature(double& temperature) const = 0;
 
     private:
+        /**
+         * @brief Small helper method to be wrapped in a timer for updating the temperature from the sensors
+         */
+        void update_temperature_reading() {
+            // Update temperature and detect errors:
+            auto updated = sample_temperature(last_temperature_);
+            if (updated) {
+                // Reset error counter and error state
+                bad_readings_ = 0;
+                error_ = false;
+
+                // Update moving average
+                update_moving_average();
+            }
+            else if (!error_) {
+                // Increment error counter
+                bad_readings_++;
+            }
+
+            if (bad_readings_ >= max_bad_treadings_ && !error_) {
+                error_ = true;
+                LOGF(ERROR, "Temperature sensor malfunction, %i consecutive errors", bad_readings_);
+            }
+        }
+
+        Timer update_temperature;
+        double last_temperature_{};
+        int bad_readings_{0};
+        int max_bad_treadings_{10};
+        bool error_{false};
+
         /**
          * @brief FIR moving average filter for software brew detection
          */
@@ -130,15 +136,8 @@ class TempSensor {
             }
         }
 
-        float last_temperature_{};
-        float average_temp_rate_{};
-
-        int bad_readings_{0};
-        int max_bad_treadings_{10};
-
-        bool error_{false};
-
         // Moving average:
+        double average_temp_rate_{};
         constexpr static size_t numValues = 15;
         std::array<double, numValues> tempValues{};        // array of temp values
         std::array<unsigned long, numValues> timeValues{}; // array of time values

--- a/src/hardware/TempSensor.h
+++ b/src/hardware/TempSensor.h
@@ -70,9 +70,12 @@ class TempSensor {
          * @brief Small helper method to be wrapped in a timer for updating the temperature from the sensors
          */
         void update_temperature_reading() {
+            LOG(TRACE, "Attempting temperature reading");
             // Update temperature and detect errors:
             auto updated = sample_temperature(last_temperature_);
             if (updated) {
+                LOGF(DEBUG, "Temperature reading successful: %.1f", last_temperature_);
+
                 // Reset error counter and error state
                 bad_readings_ = 0;
                 error_ = false;

--- a/src/hardware/TempSensor.h
+++ b/src/hardware/TempSensor.h
@@ -44,8 +44,7 @@ class TempSensor {
         /**
          * @brief Default destructor
          */
-        virtual ~TempSensor() {
-        }
+        virtual ~TempSensor() = default;
 
         /**
          * @brief check sensor value.
@@ -89,7 +88,7 @@ class TempSensor {
          *          implemented by every child class.
          * @return Temperature in degrees Celsius
          */
-        virtual float sample_temperature() const = 0;
+        virtual bool sample_temperature(double& temperature) const = 0;
 
     private:
         /**

--- a/src/hardware/TempSensor.h
+++ b/src/hardware/TempSensor.h
@@ -70,11 +70,10 @@ class TempSensor {
          * @brief Small helper method to be wrapped in a timer for updating the temperature from the sensors
          */
         void update_temperature_reading() {
-            LOG(TRACE, "Attempting temperature reading");
             // Update temperature and detect errors:
             auto updated = sample_temperature(last_temperature_);
             if (updated) {
-                LOGF(DEBUG, "Temperature reading successful: %.1f", last_temperature_);
+                LOGF(TRACE, "Temperature reading successful: %.1f", last_temperature_);
 
                 // Reset error counter and error state
                 bad_readings_ = 0;
@@ -85,6 +84,7 @@ class TempSensor {
             }
             else if (!error_) {
                 // Increment error counter
+                LOGF(DEBUG, "Error during temperature reading, incrementing error counter to %i", bad_readings_);
                 bad_readings_++;
             }
 

--- a/src/hardware/TempSensorDallas.cpp
+++ b/src/hardware/TempSensorDallas.cpp
@@ -14,7 +14,7 @@ TempSensorDallas::TempSensorDallas(int GPIOPin) {
     dallasSensor_->setResolution(sensorDeviceAddress_, 10);
 }
 
-float TempSensorDallas::getTemperatureCelsius() const {
+float TempSensorDallas::sample_temperature() const {
     dallasSensor_->requestTemperatures();
     return dallasSensor_->getTempCByIndex(0);
 }

--- a/src/hardware/TempSensorDallas.cpp
+++ b/src/hardware/TempSensorDallas.cpp
@@ -12,9 +12,32 @@ TempSensorDallas::TempSensorDallas(int GPIOPin) {
     dallasSensor_->begin();
     dallasSensor_->getAddress(sensorDeviceAddress_, 0);
     dallasSensor_->setResolution(sensorDeviceAddress_, 10);
+
+    // Request first temperature conversion directly:
+    dallasSensor_->requestTemperaturesByAddress(sensorDeviceAddress_);
 }
 
-float TempSensorDallas::sample_temperature() const {
-    dallasSensor_->requestTemperatures();
-    return dallasSensor_->getTempCByIndex(0);
+bool TempSensorDallas::sample_temperature(double& temperature) const {
+
+    // Read temperature from device
+    auto temp = dallasSensor_->getTempC(sensorDeviceAddress_);
+
+    // Check error codes:
+    if (temp == DEVICE_DISCONNECTED_C) {
+        LOG(WARNING, "Temperature sensor not connected");
+        return false;
+    }
+    else if (temp == DEVICE_FAULT_OPEN_C || temp == DEVICE_FAULT_SHORTGND_C || temp == DEVICE_FAULT_SHORTVDD_C) {
+        LOG(WARNING, "Issue with temperature sensor connection, check wiring");
+        return false;
+    }
+
+    // All fine, return temp:
+    temperature = temp;
+
+    // Request next temperature conversion from device, to be read the next time
+    // For 10-bit resolution the conversion takes around 188ms and our temperature reading timer clocks at 400ms - checks out!
+    dallasSensor_->requestTemperaturesByAddress(sensorDeviceAddress_);
+
+    return true;
 }

--- a/src/hardware/TempSensorDallas.h
+++ b/src/hardware/TempSensorDallas.h
@@ -12,7 +12,9 @@
 class TempSensorDallas : public TempSensor {
     public:
         TempSensorDallas(int GPIOPin);
-        float getTemperatureCelsius() const override;
+
+    protected:
+        float sample_temperature() const override;
 
     private:
         OneWire* oneWire_;

--- a/src/hardware/TempSensorDallas.h
+++ b/src/hardware/TempSensorDallas.h
@@ -14,7 +14,7 @@ class TempSensorDallas : public TempSensor {
         TempSensorDallas(int GPIOPin);
 
     protected:
-        float sample_temperature() const override;
+        bool sample_temperature(double& temperature) const override;
 
     private:
         OneWire* oneWire_;

--- a/src/hardware/TempSensorTSIC.cpp
+++ b/src/hardware/TempSensorTSIC.cpp
@@ -15,6 +15,6 @@ TempSensorTSIC::TempSensorTSIC(int GPIOPin) {
     tsicSensor_->begin();
 }
 
-float TempSensorTSIC::getTemperatureCelsius() const {
+float TempSensorTSIC::sample_temperature() const {
     return tsicSensor_->getTemp(MAX_CHANGERATE);
 }

--- a/src/hardware/TempSensorTSIC.cpp
+++ b/src/hardware/TempSensorTSIC.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "TempSensorTSIC.h"
+#include "Logger.h"
 
 #define MAX_CHANGERATE 15
 
@@ -16,5 +17,14 @@ TempSensorTSIC::TempSensorTSIC(int GPIOPin) {
 }
 
 float TempSensorTSIC::sample_temperature() const {
-    return tsicSensor_->getTemp(MAX_CHANGERATE);
+    auto temp = tsicSensor_->getTemp(MAX_CHANGERATE);
+
+    if (temp == 222) {
+        LOG(WARNING, "Temperature reading failed");
+    }
+    else if (temp == 221) {
+        LOG(WARNING, "Temperature sensor not connected");
+    }
+
+    return temp;
 }

--- a/src/hardware/TempSensorTSIC.cpp
+++ b/src/hardware/TempSensorTSIC.cpp
@@ -16,15 +16,18 @@ TempSensorTSIC::TempSensorTSIC(int GPIOPin) {
     tsicSensor_->begin();
 }
 
-float TempSensorTSIC::sample_temperature() const {
+bool TempSensorTSIC::sample_temperature(double& temperature) const {
     auto temp = tsicSensor_->getTemp(MAX_CHANGERATE);
 
     if (temp == 222) {
         LOG(WARNING, "Temperature reading failed");
+        return false;
     }
     else if (temp == 221) {
         LOG(WARNING, "Temperature sensor not connected");
+        return false;
     }
 
-    return temp;
+    temperature = temp;
+    return true;
 }

--- a/src/hardware/TempSensorTSIC.h
+++ b/src/hardware/TempSensorTSIC.h
@@ -14,7 +14,7 @@ class TempSensorTSIC : public TempSensor {
         TempSensorTSIC(int GPIOPin);
 
     protected:
-        float sample_temperature() const override;
+        bool sample_temperature(double& temperature) const override;
 
     private:
         ZACwire* tsicSensor_;

--- a/src/hardware/TempSensorTSIC.h
+++ b/src/hardware/TempSensorTSIC.h
@@ -12,7 +12,9 @@
 class TempSensorTSIC : public TempSensor {
     public:
         TempSensorTSIC(int GPIOPin);
-        float getTemperatureCelsius() const override;
+
+    protected:
+        float sample_temperature() const override;
 
     private:
         ZACwire* tsicSensor_;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -447,32 +447,6 @@ void testEmergencyStop() {
 }
 
 /**
- * @brief Refresh temperature.
- *      Each time checkSensor() is called to verify the value.
- *      If the value is not valid, new data is not stored.
- */
-void refreshTemp() {
-    unsigned long currentMillisTemp = millis();
-    previousInput = temperature;
-
-    if (currentMillisTemp - previousMillistemp >= tempSensor->getSamplingInterval()) {
-        previousMillistemp = currentMillisTemp;
-
-        temperature = tempSensor->getCurrentTemperature();
-
-        if (machineState != kSteam) {
-            temperature -= brewTempOffset;
-        }
-
-        if (!tempSensor->check(temperature, brewTempOffset)) {
-            temperature = previousInput;
-            return; // if sensor data is not valid, abort function; Sensor must
-                    // be read at least one time at system startup
-        }
-    }
-}
-
-/**
  * @brief Switch to offline mode if maxWifiReconnects were exceeded during boot
  */
 void initOfflineMode() {
@@ -1864,7 +1838,13 @@ void looppid() {
         checkWifi();
     }
 
-    refreshTemp();       // update temperature values
+    // Update the temperature:
+    temperature = tempSensor->getCurrentTemperature();
+
+    if (machineState != kSteam) {
+        temperature -= brewTempOffset;
+    }
+
     testEmergencyStop(); // test if temp is too high
     bPID.Compute();      // the variable pidOutput now has new values from PID (will be written to heater pin in ISR.cpp)
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -294,7 +294,6 @@ const int waterCountsNeeded = 3;    // Number of same readings to change water s
 
 // Moving average for software brew detection
 double tempRateAverage = 0;            // average value of temp values
-double tempChangeRateAverageMin = 0;
 unsigned long timeBrewDetection = 0;
 int isBrewDetected = 0;                // flag is set if brew was detected
 bool movingAverageInitialized = false; // flag set when average filter is initialized, also used for sensor check
@@ -491,10 +490,6 @@ void calculateTemperatureMovingAverage() {
     }
 
     tempRateAverage = totalTempChangeRateSum / numValues * 100;
-
-    if (tempRateAverage < tempChangeRateAverageMin) {
-        tempChangeRateAverageMin = tempRateAverage;
-    }
 
     if (valueIndex >= numValues - 1) {
         // ...wrap around to the beginning:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1732,6 +1732,10 @@ void setup() {
         pidON = 1;                  // pid on
     }
 
+    // Start the logger
+    Logger::begin();
+    Logger::setLevel(LOGLEVEL);
+
     // Initialize PID controller
     bPID.SetSampleTime(windowSize);
     bPID.SetOutputLimits(0, windowSize);
@@ -1775,10 +1779,6 @@ void setup() {
     setupDone = true;
 
     enableTimer1();
-
-    // Start the logger
-    Logger::begin();
-    Logger::setLevel(LOGLEVEL);
 
     double fsUsage = ((double)LittleFS.usedBytes() / LittleFS.totalBytes()) * 100;
     LOGF(INFO, "LittleFS: %d%% (used %ld bytes from %ld bytes)", (int)ceil(fsUsage), LittleFS.usedBytes(), LittleFS.totalBytes());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -325,7 +325,7 @@ PID bPID(&temperature, &pidOutput, &setpoint, aggKp, aggKi, aggKd, 1, DIRECT);
 
 #include "brewHandler.h"
 
-Timer logbrew([&]() { LOGF(DEBUG, "(tB,T,hra) --> %5.2f %6.2f %8.2f", (double)(millis() - startingTime) / 1000, temperature, tempRateAverage); }, 500);
+Timer logbrew([&]() { LOGF(DEBUG, "(tB,T,hra) --> %5.2f %6.2f %8.2f", (double)(millis() - startingTime) / 1000, temperature, tempSensor->getAverageTemperatureRate()); }, 500);
 
 // Embedded HTTP Server
 #include "embeddedWebserver.h"


### PR DESCRIPTION
This PR

* moves error checking into the respective temperature reading classes
* checks for the appropriate error codes provided by the libraries
* moves the temperature sampling / reading into the `TempSensor` class and triggers it with a `Timer`

This means that

* No bogus/wrong temperature values will ever reach the PID, only valid ones are returned. Worst case scenario is errors at startup, then a temperature of 0degC will be returned
* Lots of global `main()` code could be removed and complexity reduced, errors as well as temperature are directly fetched from sensor
* ...and a few other niceties.