### PR TITLE
IOSwitch: Allow seeting initial state

### DIFF
--- a/src/hardware/IOSwitch.cpp
+++ b/src/hardware/IOSwitch.cpp
@@ -7,8 +7,9 @@
 #include "IOSwitch.h"
 #include "GPIOPin.h"
 
-IOSwitch::IOSwitch(int pinNumber, GPIOPin::Type pinType, Type switchType, Mode mode) :
-    Switch(switchType, mode), gpio(pinNumber, pinType) {
+#include "Logger.h"
+IOSwitch::IOSwitch(int pinNumber, GPIOPin::Type pinType, Type switchType, Mode mode, uint8_t initialState) :
+    Switch(switchType, mode), gpio(pinNumber, pinType), lastState(initialState), currentState(initialState) {
 }
 
 bool IOSwitch::isPressed() {

--- a/src/hardware/IOSwitch.h
+++ b/src/hardware/IOSwitch.h
@@ -23,7 +23,7 @@ class IOSwitch : public Switch {
          * @param switchType Type of the switch
          * @param mode Operation mode of the switch
          */
-        IOSwitch(int pinNumber, GPIOPin::Type pinType, Type switchType = MOMENTARY, Mode mode = NORMALLY_OPEN);
+        IOSwitch(int pinNumber, GPIOPin::Type pinType, Type switchType = MOMENTARY, Mode mode = NORMALLY_OPEN, uint8_t initialState = LOW);
 
         /**
          * @brief Switch reading (pressed, not pressed)
@@ -44,8 +44,8 @@ class IOSwitch : public Switch {
         GPIOPin gpio;
 
         // Switch state
-        uint8_t lastState{LOW};
-        uint8_t currentState{LOW};
+        uint8_t lastState;
+        uint8_t currentState;
 
         // Debouncing and long-press detection
         unsigned long lastStateChangeTime{0};

--- a/src/hardware/Switch.h
+++ b/src/hardware/Switch.h
@@ -29,8 +29,8 @@ class Switch {
          *          (normally-open, NO)
          */
         enum Mode {
-            NORMALLY_OPEN,
-            NORMALLY_CLOSED
+            NORMALLY_OPEN = 0,
+            NORMALLY_CLOSED = 1,
         };
 
         /**

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1918,12 +1918,17 @@ void setup() {
 }
 
 void loop() {
-    looppid();
-    loopLED();
+    // Accept potential connections for remote logging
+    Logger::update();
 
+    // Update water sensor
     loopWater();
 
-    Logger::update();
+    // Update PID settings & machine state
+    looppid();
+
+    // Update LED output based on machine state
+    loopLED();
 }
 
 void looppid() {


### PR DESCRIPTION
This is a small improvement to the IOSwitch class which allows setting the initial state.

This fixes an issue when the "water empty" state would briefly flash at startup because the sensor initial state is `LOW`, but we use `HIGH` as the "water is present" state.