### PR TITLE
Fix Emergency mode

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -277,7 +277,7 @@ SysPara<float> sysParaScaleKnownWeight(&scaleKnownWeight, 0, 2000, STO_ITEM_SCAL
 
 // Other variables
 boolean emergencyStop = false;                // Emergency stop if temperature is too high
-double EmergencyStopTemp = 120;               // Temp EmergencyStopTemp
+double EmergencyStopTemp = 145;               // Temp EmergencyStopTemp
 float inX = 0, inY = 0, inOld = 0, inSum = 0; // used for filterPressureValue()
 boolean brewDetected = 0;
 boolean setupDone = false;
@@ -438,10 +438,10 @@ Timer printDisplayTimer(&printScreen, 100);
 
 // Emergency stop if temp is too high
 void testEmergencyStop() {
-    if (temperature > EmergencyStopTemp && emergencyStop == false) {
+    if (temperature > EmergencyStopTemp) {
         emergencyStop = true;
     }
-    else if (temperature < (brewSetpoint + 5) && emergencyStop == true) {
+    else if (temperature < (setpoint + 5)) {
         emergencyStop = false;
     }
 }


### PR DESCRIPTION
**Setup**: 
Machine: Rancilio Silvia
Steam switch
Setpoint: 95°, Steam 130°
Software: master (6177b2d6)

**How to reproduce**: Machine power is toggled while being at steam temperature.
Goes into `kEmergencyStop` and unable to leave, even if the actual temperature is below steam setpoint.
Only way to leave is cooling down to < 100° (brew setpoint + 5°)
![PID_stopped](https://github.com/rancilio-pid/clevercoffee/assets/13648152/6ccfb191-c2e6-4e62-8573-af0e5e92e7f4)

**Reason**:
- `EmergencyStopTemp` is initialized to 120°. `testEmergencyStop()` immediately triggers and machine goes to `kEmergencyStop`; `setEmergencyStopTemp()` will keep the StopTemp at 120 since `kSteam` is never reached.
- Leaving the mode compares against `brewSetpoint`, i.e. 95°. So even if the recognized (and displayed) setpoint in steam mode is higher than measured temperature, machine still displays "PID stopped" and refuses to heat.

**Solution**:
- Leaving kEmergency must compare against the current `setpoint` so the mode is left whenever the temperature goes near the current chosen setpoint.
- The initial EmergencyStopTemp should be the same 145 that are used in `setEmergencyStopTemp()`, to avoid setting `emergencyStop` immediately before first execution of `setEmergencyStopTemp()`.