### PR TITLE
Exit kSteam mode when steam button is switched off

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -888,6 +888,10 @@ void handleMachineState() {
             break;
 
         case kSteam:
+            if (steamON == 0) {
+                machineState = kPidNormal;
+            }
+
             if (emergencyStop) {
                 machineState = kEmergencyStop;
             }


### PR DESCRIPTION
Add exit condition for steam state. 

As I type this I am no longer sure that this is the correct approach -- do we need special handling for trigger type steam switches, or is the variable `steamOn` filled "intelligently"? 