### PR TITLE
waterFull will reset standbytime if mashine state is KWaterEmpty

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -950,6 +950,10 @@ void handleMachineState() {
         case kWaterEmpty:
             if (waterFull) {
                 machineState = kPidNormal;
+
+                if (standbyModeOn) {
+                    resetStandbyTimer();
+                }
             }
 
             if (pidON == 0) {


### PR DESCRIPTION
if mashine is in kWaterEmpty and water gets refilled, standby time will be resetted
