### PR TITLE
Switched from pkg_resources to importlib

### DIFF
--- a/auto_firmware_version.py
+++ b/auto_firmware_version.py
@@ -1,9 +1,9 @@
-import pkg_resources
+import importlib.metadata
 
 Import("env")
 
 required_pkgs = {'dulwich'}
-installed_pkgs = {pkg.key for pkg in pkg_resources.working_set}
+installed_pkgs = {dist.metadata['Name'] for dist in importlib.metadata.distributions()}
 missing_pkgs = required_pkgs - installed_pkgs
 
 if missing_pkgs:


### PR DESCRIPTION
Switched from pkg_resources to importlib,
since pkg_resources is deprecated (and I couldn't compile with it).