### PR TITLE
fix pid off on brew detection

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1952,6 +1952,8 @@ void looppid() {
             if (!brewPIDDisabled) {
                 brewPIDDisabled = true;
                 bPID.SetMode(MANUAL);
+                pidOutput = 0;
+                heaterRelay.off();
                 LOGF(DEBUG, "disabled PID, waiting for %d seconds before enabling PID again", brewPIDDelay);
             }
         }


### PR DESCRIPTION
when detecting a brew and disabling the PID, the pidOutput needs to be set to 0 and the heater shut off manually

previously the heating continued on its last set intensity for the time set in brewPIDDelay

Screenshot before:
<img width="1065" alt="Bildschirmfoto 2025-05-28 um 09 19 18" src="https://github.com/user-attachments/assets/45f15afb-ca37-46eb-bd13-2cf7120d43cb" />

Screenshot after:
<img width="1078" alt="Bildschirmfoto 2025-05-28 um 09 13 41" src="https://github.com/user-attachments/assets/d9853127-c9c0-468b-805b-22e108041c3a" />
