### PR TITLE
Fix PonM mode for PID controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,11 +4,12 @@ src/userConfig.h
 # ignore PlatformIO build folder
 .pio/*
 
-# ignore Visual Studio Code configuration files
+# ignore configuration files
 **/.vscode
+**/.venv
+**/.idea
 
 # ignore macOS Finder configuration storage files
 **/.DS_Store
 
 platformio_extra.ini
-**/rancilio-pid.ino.cpp

--- a/src/defaults.h
+++ b/src/defaults.h
@@ -30,8 +30,6 @@ int writeSysParamsToStorage(void);
 #define AGGTN                     52     // PID Tn (regular phase)
 #define AGGTV                     11.5   // PID Tv (regular phase)
 #define AGGIMAX                   55     // PID Integrator Max (regular phase)
-#define STARTKP                   45     // PID Kp (coldstart phase)
-#define STARTTN                   130    // PID Tn (coldstart phase)
 #define STEAMKP                   150    // PID kp (steam phase)
 #define AGGBKP                    50     // PID Kp (brew detection phase)
 #define AGGBTN                    0      // PID Tn (brew detection phase)
@@ -50,10 +48,6 @@ int writeSysParamsToStorage(void);
 #define BACKFLUSH_FILL_TIME       5      // time in seconds the pump is running during backflush
 #define BACKFLUSH_FLUSH_TIME      10     // time in seconds the 3-way valve is open during backflush
 
-#define PID_KP_START_MIN         0
-#define PID_KP_START_MAX         999
-#define PID_TN_START_MIN         0
-#define PID_TN_START_MAX         999
 #define PID_KP_REGULAR_MIN       0
 #define PID_KP_REGULAR_MAX       999
 #define PID_TN_REGULAR_MIN       0

--- a/src/embeddedWebserver.h
+++ b/src/embeddedWebserver.h
@@ -58,7 +58,7 @@ void serverSetup();
 void setEepromWriteFcn(int (*fcnPtr)(void));
 
 // editable vars are specified in main.cpp
-#define EDITABLE_VARS_LEN 36
+#define EDITABLE_VARS_LEN 35
 extern std::map<String, editable_t> editableVars;
 
 // EEPROM

--- a/src/mqtt.h
+++ b/src/mqtt.h
@@ -509,8 +509,6 @@ int sendHASSIODiscoveryMsg() {
     DiscoveryObject steamSetPoint = GenerateNumberDevice("steamSetpoint", "Steam setpoint", STEAM_SETPOINT_MIN, STEAM_SETPOINT_MAX, 0.1, "°C");
     DiscoveryObject brewTempOffset = GenerateNumberDevice("brewTempOffset", "Brew Temp. Offset", BREW_TEMP_OFFSET_MIN, BREW_TEMP_OFFSET_MAX, 0.1, "°C");
     DiscoveryObject brewPidDelay = GenerateNumberDevice("brewPidDelay", "Brew Pid Delay", BREW_PID_DELAY_MIN, BREW_PID_DELAY_MAX, 0.1, "");
-    DiscoveryObject startKp = GenerateNumberDevice("startKp", "Start kP", PID_KP_START_MIN, PID_KP_START_MAX, 0.1, "");
-    DiscoveryObject startTn = GenerateNumberDevice("startTn", "Start Tn", PID_TN_START_MIN, PID_TN_START_MAX, 0.1, "");
     DiscoveryObject steamKp = GenerateNumberDevice("steamKp", "Start Kp", PID_KP_STEAM_MIN, PID_KP_STEAM_MAX, 0.1, "");
     DiscoveryObject aggKp = GenerateNumberDevice("aggKp", "aggKp", PID_KP_REGULAR_MIN, PID_KP_REGULAR_MAX, 0.1, "");
     DiscoveryObject aggTn = GenerateNumberDevice("aggTn", "aggTn", PID_TN_REGULAR_MIN, PID_TN_REGULAR_MAX, 0.1, "");
@@ -553,8 +551,6 @@ int sendHASSIODiscoveryMsg() {
                                                      steamSetPoint,
                                                      brewTempOffset,
                                                      brewPidDelay,
-                                                     startKp,
-                                                     startTn,
                                                      steamKp,
                                                      aggKp,
                                                      aggTn,

--- a/src/storage.h
+++ b/src/storage.h
@@ -10,7 +10,7 @@
 // storage items
 typedef enum {
     STO_ITEM_PID_ON,                    // PID on/off state
-    STO_ITEM_PID_START_PONM,            // Use PonM for cold start phase (otherwise use normal PID and same params)
+    STO_ITEM_PID_USE_PONM,              // Use PonM mode for PID controller (Proportional on Measurement)
     STO_ITEM_PID_KP_START,              // PID P part at cold start phase
     STO_ITEM_PID_TN_START,              // PID I part at cold start phase
     STO_ITEM_PID_KP_REGULAR,            // PID P part at regular operation
@@ -99,7 +99,7 @@ typedef struct __attribute__((packed)) {
         uint8_t freeToUse10;
         double brewDetectionThreshold;
         uint8_t wifiCredentialsSaved;
-        uint8_t useStartPonM;
+        uint8_t pidUsePonM;
         double pidKpStart;
         uint8_t freeToUse12[2];
         uint8_t softApEnabledCheck;
@@ -151,11 +151,11 @@ static const sto_data_t itemDefaults PROGMEM = {
     BD_SENSITIVITY,                                                                                                                 // STO_ITEM_BD_THRESHOLD
     WIFI_CREDENTIALS_SAVED,                                                                                                         // STO_ITEM_WIFI_CREDENTIALS_SAVED
     0,                                                                                                                              // STO_ITEM_USE_START_PON_M
-    STARTKP,                                                                                                                        // STO_ITEM_PID_KP_START
+    0,                                                                                                                              // free to use
     {0xFF, 0xFF},                                                                                                                   // free to use
     0,                                                                                                                              // STO_ITEM_SOFT_AP_ENABLED_CHECK
     {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF},                                                                         // free to use
-    STARTTN,                                                                                                                        // STO_ITEM_PID_TN_START
+    0,                                                                                                                              // free to use
     {0xFF, 0xFF},                                                                                                                   // free to use
     "",                                                                                                                             // STO_ITEM_WIFI_SSID
     "",                                                                                                                             // STO_ITEM_WIFI_PASSWORD
@@ -269,9 +269,9 @@ static inline int32_t getItemAddr(sto_item_id_t itemId, uint16_t* maxItemSize = 
             size = STRUCT_MEMBER_SIZE(sto_data_t, wifiCredentialsSaved);
             break;
 
-        case STO_ITEM_PID_START_PONM:
-            addr = offsetof(sto_data_t, useStartPonM);
-            size = STRUCT_MEMBER_SIZE(sto_data_t, useStartPonM);
+        case STO_ITEM_PID_USE_PONM:
+            addr = offsetof(sto_data_t, pidUsePonM);
+            size = STRUCT_MEMBER_SIZE(sto_data_t, pidUsePonM);
             break;
 
         case STO_ITEM_PID_KP_START:


### PR DESCRIPTION
The PID controller was still using the P and I values of the old cold start mode which has since been removed. This commit refactors the method that sets the PID tunings so that it takes PonM into account when enabled.