### PR TITLE
fixed mqtt crashing caused by old weightSetpoint

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1397,7 +1397,7 @@ void setup() {
 #endif
 
 #if FEATURE_SCALE == 1
-    mqttVars["weightSetpoint"] = [] { return &editableVars.at("SCALE_WEIGHTSETPOINT"); };
+    mqttVars["targetBrewWeight"] = [] { return &editableVars.at("SCALE_TARGET_BREW_WEIGHT"); };
     mqttVars["scaleCalibration"] = [] { return &editableVars.at("SCALE_CALIBRATION"); };
 #if SCALE_TYPE == 0
     mqttVars["scale2Calibration"] = [] { return &editableVars.at("SCALE2_CALIBRATION"); };


### PR DESCRIPTION
When using scales and MQTT it would bootloop when trying to send the old weightSetpoint. Replaced with targetBrewWeight and it runs well, though there may be more to clean up in this area.