### PR TITLE
Option: heat while water tank is empty

### DIFF
--- a/CONFIG_REFERENCE.md
+++ b/CONFIG_REFERENCE.md
@@ -310,6 +310,11 @@ For each LED type (status, brew, steam):
     - `1`: Normally closed
 - **Description**: Water tank sensor switch mode
 
+### `hardware.sensors.watertank.heaterKeepOn`
+- **Type**: Boolean
+- **Default**: `false`
+- **Description**: Keep heater on when tank is empty
+
 ## Switches
 
 For each switch type (brew, power, steam):

--- a/src/Config.h
+++ b/src/Config.h
@@ -355,6 +355,7 @@ class Config {
             _configDefs.emplace("hardware.sensors.pressure.enabled", ConfigDef::forBool(false));
             _configDefs.emplace("hardware.sensors.watertank.enabled", ConfigDef::forBool(false));
             _configDefs.emplace("hardware.sensors.watertank.mode", ConfigDef::forInt(Switch::NORMALLY_CLOSED, 0, 1));
+            _configDefs.emplace("hardware.sensors.watertank.heaterKeepOn", ConfigDef::forBool(false));
 
             // Scale
             _configDefs.emplace("hardware.sensors.scale.enabled", ConfigDef::forBool(false));

--- a/src/ParameterRegistry.cpp
+++ b/src/ParameterRegistry.cpp
@@ -1183,6 +1183,17 @@ void ParameterRegistry::initialize(Config& config) {
     );
 
     addBoolConfigParam(
+        "hardware.sensors.watertank.heaterKeepOn",
+        "Keep Heater On When Tank Empty",
+        sHardwareSensorSection,
+        2423,
+        nullptr,
+        "Warning: this keeps PID and heater active even when the water tank is reported as empty",
+        [&config] { return config.get<bool>("hardware.sensors.watertank.enabled"); },
+        false
+    );
+
+    addBoolConfigParam(
         "hardware.sensors.scale.enabled",
         "Enable Scale",
         sHardwareSensorSection,

--- a/src/hardware/tempsensors/TempSensor.h
+++ b/src/hardware/tempsensors/TempSensor.h
@@ -77,6 +77,9 @@ class TempSensor {
                 LOGF(TRACE, "Temperature reading successful: %.1f", last_temperature_);
 
                 // Reset error counter and error state
+                if (bad_readings_ > 0) {
+                    LOGF(DEBUG, "Temperature reading successful: %.1f, cleared error counter", last_temperature_);
+                }
                 bad_readings_ = 0;
                 error_ = false;
                 temperatureUpdateRunning = true;
@@ -86,8 +89,8 @@ class TempSensor {
             }
             else if (!error_) {
                 // Increment error counter
-                LOGF(DEBUG, "Error during temperature reading, incrementing error counter to %i", bad_readings_);
                 bad_readings_++;
+                LOGF(WARNING, "Error during temperature reading, incrementing error counter to %i", bad_readings_);
             }
 
             if (bad_readings_ >= max_bad_treadings_ && !error_) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1119,6 +1119,10 @@ void setup() {
                 mqttSensors["pressure"] = [] { return inputPressureFilter; };
             }
 
+            if (config.get<bool>("hardware.sensors.watertank.enabled")) {
+                mqttSensors["waterTankFull"] = [] { return waterTankFull ? 1.0 : 0.0; };
+            }
+
             snprintf(topic_will, sizeof(topic_will), "%s%s/%s", mqtt_topic_prefix.c_str(), hostname.c_str(), "status");
             snprintf(topic_set, sizeof(topic_set), "%s%s/+/%s", mqtt_topic_prefix.c_str(), hostname.c_str(), "set");
             mqtt.setServer(mqtt_server_ip.c_str(), mqtt_server_port);
@@ -1417,7 +1421,8 @@ void loopPid() {
     }
 
     // Check if PID should run or not. If not, set to manual and force output to zero
-    if (machineState == kPidDisabled || machineState == kWaterTankEmpty || machineState == kSensorError || machineState == kEmergencyStop || machineState == kStandby || machineState == kBackflush || brewPidDisabled) {
+    if (machineState == kPidDisabled || (machineState == kWaterTankEmpty && !config.get<bool>("hardware.sensors.watertank.heaterKeepOn")) || machineState == kSensorError || machineState == kEmergencyStop ||
+        machineState == kStandby || machineState == kBackflush || brewPidDisabled) {
         if (bPID.GetMode() == 1) {
             // Force PID shutdown
             bPID.SetMode(0);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1120,7 +1120,7 @@ void setup() {
             }
 
             if (config.get<bool>("hardware.sensors.watertank.enabled")) {
-                mqttSensors["waterTankFull"] = [] { return waterTankFull ? 1.0 : 0.0; };
+                mqttSensors["waterTankEmpty"] = [] { return waterTankFull ? 0.0 : 1.0; };
             }
 
             snprintf(topic_will, sizeof(topic_will), "%s%s/%s", mqtt_topic_prefix.c_str(), hostname.c_str(), "status");

--- a/src/mqtt.h
+++ b/src/mqtt.h
@@ -567,6 +567,55 @@ inline DiscoveryObject GenerateSensorDevice(const char* name, const char* displa
 }
 
 /**
+ * @brief Generate a binary sensor device for Home Assistant MQTT discovery
+ *
+ * @param name The name of the sensor (used in MQTT topics)
+ * @param displayName The display name of the sensor (shown in Home Assistant)
+ * @param device_class HA binary_sensor device class (e.g. "moisture", "problem", "")
+ * @param payload_on Payload that represents the on/true state (default: "1")
+ * @param payload_off Payload that represents the off/false state (default: "0")
+ * @return A `DiscoveryObject` containing the binary sensor device configuration
+ */
+inline DiscoveryObject GenerateBinarySensorDevice(const char* name, const char* displayName, const char* device_class = "", const char* payload_on = "1", const char* payload_off = "0") {
+    DiscoveryObject sensor_device;
+
+    char mqtt_topic[128];
+    char unique_id[80];
+    char topic_buffer[160];
+
+    snprintf(mqtt_topic, sizeof(mqtt_topic), "%s%s", mqtt_topic_prefix.c_str(), hostname.c_str());
+    snprintf(unique_id, sizeof(unique_id), "clevercoffee-%s", hostname);
+    snprintf(sensor_device.discovery_topic, sizeof(sensor_device.discovery_topic), "%s/binary_sensor/%s/%s/config", mqtt_hassio_discovery_prefix, unique_id, name);
+
+    JsonDocument sensorConfigDoc;
+    sensorConfigDoc["name"] = displayName;
+    snprintf(topic_buffer, sizeof(topic_buffer), "%s/%s", mqtt_topic, name);
+    sensorConfigDoc["state_topic"] = String(topic_buffer);
+    snprintf(topic_buffer, sizeof(topic_buffer), "%s-%s", unique_id, name);
+    sensorConfigDoc["unique_id"] = String(topic_buffer);
+    sensorConfigDoc["payload_on"] = payload_on;
+    sensorConfigDoc["payload_off"] = payload_off;
+
+    if (device_class[0] != '\0') {
+        sensorConfigDoc["device_class"] = device_class;
+    }
+
+    sensorConfigDoc["payload_available"] = "online";
+    sensorConfigDoc["payload_not_available"] = "offline";
+    snprintf(topic_buffer, sizeof(topic_buffer), "%s/status", mqtt_topic);
+    sensorConfigDoc["availability_topic"] = String(topic_buffer);
+
+    JsonObject device = sensorConfigDoc["device"].to<JsonObject>();
+    device["identifiers"] = hostname;
+    device["manufacturer"] = "CleverCoffee";
+    device["name"] = hostname;
+
+    serializeJson(sensorConfigDoc, sensor_device.payload_json, sizeof(sensor_device.payload_json));
+
+    return sensor_device;
+}
+
+/**
  * @brief Generate a number device for Home Assistant MQTT discovery
  *
  * This function generates a number device configuration for Home Assistant MQTT discovery. It creates a `DiscoveryObject` containing the necessary information for Home Assistant to discover and control the number device.
@@ -699,6 +748,10 @@ inline int sendHASSIODiscoveryMsg() {
 
     if (config.get<bool>("hardware.sensors.pressure.enabled")) {
         failures += publishDiscovery(GenerateSensorDevice("pressure", "Pressure", "bar", "pressure"));
+    }
+
+    if (config.get<bool>("hardware.sensors.watertank.enabled")) {
+        failures += publishDiscovery(GenerateBinarySensorDevice("waterTankFull", "Water Tank", "moisture", "1.00", "0.00"));
     }
 
     if (failures > 0) {

--- a/src/mqtt.h
+++ b/src/mqtt.h
@@ -751,7 +751,7 @@ inline int sendHASSIODiscoveryMsg() {
     }
 
     if (config.get<bool>("hardware.sensors.watertank.enabled")) {
-        failures += publishDiscovery(GenerateBinarySensorDevice("waterTankFull", "Water Tank", "moisture", "1.00", "0.00"));
+        failures += publishDiscovery(GenerateBinarySensorDevice("waterTankEmpty", "Water Tank", "problem", "1.00", "0.00"));
     }
 
     if (failures > 0) {


### PR DESCRIPTION
Add a configuration parameter to keep the PID and heating on in case the water tank is reported as empty. The boiler is usually still full of water.

Export the MQTT sensor "~~waterTankFull~~" "waterTankEmpty" because the machine state is not sufficient anymore to detect an empt tank. The state is recognised as ~~dry/wet~~ "problem" by HomeAssistant.

<img width="687" height="325" alt="image" src="https://github.com/user-attachments/assets/0d7368cc-7107-47fb-abe1-b8e630d788fd" />
