### PR TITLE
Make the power-on behaviour configurable instead of always heating

### DIFF
--- a/src/Config.h
+++ b/src/Config.h
@@ -236,6 +236,7 @@ class Config {
 
             // PID general
             _configDefs.emplace("pid.enabled", ConfigDef::forBool(false));
+            _configDefs.emplace("pid.power_on_behaviour", ConfigDef::forInt(0, 0, 2));
             _configDefs.emplace("pid.use_ponm", ConfigDef::forBool(false));
             _configDefs.emplace("pid.ema_factor", ConfigDef::forDouble(EMA_FACTOR, PID_EMA_FACTOR_MIN, PID_EMA_FACTOR_MAX));
 

--- a/src/ParameterRegistry.cpp
+++ b/src/ParameterRegistry.cpp
@@ -51,6 +51,7 @@ const char* switchModes[2] = {"Normally Open", "Normally Closed"};
 const char* relayTriggerTypes[2] = {"Low Trigger", "High Trigger"};
 
 static constexpr const char* const brewModes[] = {"Manual", "Automatic"};
+static constexpr const char* const powerOnBehaviours[] = {"Standby", "Heat up", "Restore last state"};
 static constexpr const char* const displayTemplates[] = {"Standard", "Minimal", "Temp only", "Scale", "Upright"};
 static constexpr const char* const displayLanguages[] = {"Deutsch", "English", "Español"};
 static constexpr const char* const blinkingModes[] = {"Off", "Near Setpoint", "Away From Setpoint"};
@@ -497,6 +498,19 @@ void ParameterRegistry::initialize(Config& config) {
     }
 
     // Power Section
+    addEnumConfigParam(
+        "pid.power_on_behaviour",
+        "Power-On Behaviour",
+        sPowerSection,
+        800,
+        nullptr,
+        powerOnBehaviours,
+        3,
+        "What the machine does when it powers up: stay in standby, start heating right away "
+        "(e.g. when it is switched on by a smart plug or a timer), or restore the state it "
+        "was in before it lost power"
+    );
+
     addBoolConfigParam(
         "standby.enabled",
         "Enable Standby Timer",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -896,6 +896,17 @@ void testTimer(void) {
     }
 }
 
+/**
+ * @enum PowerOnBehaviour
+ * @brief What the machine does when it powers up
+ * @details Values must match the order of powerOnBehaviours[] in ParameterRegistry.cpp.
+ */
+enum PowerOnBehaviour {
+    kPowerOnStandby = 0, ///< Stay in standby, do not heat (default)
+    kPowerOnHeat = 1,    ///< Start heating right away (smart plug / timer setups)
+    kPowerOnRestore = 2, ///< Restore the state the machine was in before it lost power
+};
+
 extern const char sysVersion[] = STR(AUTO_VERSION);
 
 void setup() {
@@ -1198,10 +1209,36 @@ void setup() {
 
     systemInitialized = true;
 
-    // For momentary switches, start in normal operation mode
-    if (config.get<bool>("hardware.switches.power.enabled") && config.get<int>("hardware.switches.power.type") == Switch::MOMENTARY) {
-        machineState = kPidNormal;
-        setRuntimePidState(true);
+    // Apply the configured power-on behaviour. Toggle switches are handled below,
+    // where the machine state follows the physical switch position instead.
+    if (!(config.get<bool>("hardware.switches.power.enabled") && config.get<int>("hardware.switches.power.type") == Switch::TOGGLE)) {
+        switch (config.get<int>("pid.power_on_behaviour")) {
+            case kPowerOnHeat:
+                machineState = kPidNormal;
+                // Required: standbyModeRemainingTimeMillis is statically initialised
+                // from standbyModeTime, which is still 0 at that point, and the state
+                // machine treats 0 as "standby timeout elapsed" -- without this the
+                // machine would drop straight back into kStandby.
+                resetStandbyTimer(kPidNormal);
+                setRuntimePidState(true);
+                break;
+
+            case kPowerOnRestore:
+                // pidON was restored from the config by syncGlobalVariables() above
+                machineState = pidON ? kPidNormal : kStandby;
+
+                if (pidON) {
+                    resetStandbyTimer(kPidNormal);
+                }
+
+                break;
+
+            case kPowerOnStandby:
+            default:
+                machineState = kStandby;
+                setRuntimePidState(false);
+                break;
+        }
     }
 
     // For toggle switches, force PidOn to switch state mode


### PR DESCRIPTION
At the end of setup(), machines with a momentary power switch were put into kPidNormal ("start in normal operation mode"), so the boiler starts heating on its own after every reboot, power loss or OTA update -- with nobody necessarily present.

Simply booting into standby would be a regression for a common setup, though: plenty of machines are powered up by a smart plug or a timer, and there "mains power applied" is precisely the signal to start heating. So make the behaviour configurable rather than picking one for everyone:

  pid.power_on_behaviour
    0 = Standby             stay off (new default)
    1 = Heat up             previous behaviour, for smart plug/timer setups
    2 = Restore last state  resume whatever the machine was doing before

The default is the safe one, which is the point: anyone who never touches the setting no longer gets an unattended heat-up, while users who switch their machine on by mains power keep their behaviour by selecting "Heat up".

"Restore last state" also gives the persistence of pid.enabled an actual purpose. pidON is bound to a config value and is therefore written to flash on every on/off, but that value was never read back in a meaningful way -- in this mode it finally is.

Toggle switches are unaffected: there the machine state follows the physical switch position, which is evaluated immediately after this. The setting applies to momentary switches and to setups without a power switch, which previously also resumed heating from the stored state.

The paths that end up in kPidNormal call resetStandbyTimer(), which the previous unconditional boot into kPidNormal was missing: standbyModeRemainingTimeMillis is statically initialised from standbyModeTime, which is still 0 before setup() has read the config, and the state machine treats 0 as "standby timeout elapsed". Without the reset the machine dropped straight back into kStandby and only came up again via case kStandby's `if (pidON) -> kPidNormal` a few seconds later.

Verified on a Rancilio Silvia E with the standby timer enabled (35 min), all three modes:

  Standby   reboot -> stays off
  Heat up   machine explicitly switched off before the reboot -> heats
            afterwards (PID Normal, 14 % heater power)
  Restore   was on -> heats, and now goes to PID Normal directly instead
            of bouncing through standby; was off -> stays off