### PR TITLE
Make the momentary power switch behave consistently with TOGGLE and HA

### DIFF
--- a/src/powerHandler.h
+++ b/src/powerHandler.h
@@ -64,7 +64,12 @@ inline void checkPowerSwitch() {
                     trackingPressTime = true;
                 }
 
-                if (machineState == kStandby) {
+                // The TOGGLE branch above checks `kStandby || kPidDisabled`, but this
+                // one only looked at kStandby. Switching the machine off via MQTT or
+                // the web UI (pidON = false) lands in kPidDisabled (display on,
+                // showing "Standby"), so a button press fell through to the else
+                // branch and shut down into kStandby instead of waking the machine.
+                if (machineState == kStandby || machineState == kPidDisabled) {
                     machineState = kPidNormal;
                     resetStandbyTimer(kPidNormal);
                     setRuntimePidState(true);

--- a/src/powerHandler.h
+++ b/src/powerHandler.h
@@ -81,8 +81,26 @@ inline void checkPowerSwitch() {
                 else {
                     performSafeShutdown();
                     machineState = kStandby;
+
+                    // Blanking the display immediately (both timers forced to 0) is
+                    // inconsistent with switching the machine off via MQTT or the web
+                    // UI, which leaves the standby screen up and lets the regular
+                    // TIME_TO_DISPLAY_OFF countdown blank it. Do the same here: enter
+                    // standby now, blank the display after TIME_TO_DISPLAY_OFF.
+                    // Backdating standbyModeStartTimeMillis by the standby timeout makes
+                    // updateStandbyTimer() count down exactly TIME_TO_DISPLAY_OFF from
+                    // now; the unsigned wrap-around is safe because
+                    // currentTime - (currentTime - X) == X holds either way.
                     standbyModeRemainingTimeMillis = 0;
-                    standbyModeRemainingTimeDisplayOffMillis = 0;
+
+                    if (standbyModeOn) {
+                        standbyModeRemainingTimeDisplayOffMillis = TIME_TO_DISPLAY_OFF_MILLIS;
+                        standbyModeStartTimeMillis = millis() - getStandbyTimeoutMillis();
+                    }
+                    else {
+                        // standby timer disabled -> nothing would count down, blank now
+                        standbyModeRemainingTimeDisplayOffMillis = 0;
+                    }
                 }
             }
             else if (!currStatePowerSwitchPressed) {


### PR DESCRIPTION
Two inconsistencies in the MOMENTARY branch of checkPowerSwitch(), both
relative to behaviour that already exists elsewhere in the code.

**1. The button did not wake the machine from kPidDisabled**

There are two "off" states: kPidDisabled (display on, showing "Standby",
where MQTT and the web UI land when setting pidON = false) and kStandby
(display off). The TOGGLE branch treats both as off and wakes from
either; the MOMENTARY branch only checked kStandby.

After switching the machine off remotely, a button press therefore fell
through to the else branch, ran performSafeShutdown() and moved it to
kStandby -- the display went blank and the user had to press a second
time to actually turn the machine on.

**2. Switching off blanked the display instantly**

Using the power button blanked the display immediately, while switching
off via MQTT or the web UI left the standby screen up and blanked it
after the regular TIME_TO_DISPLAY_OFF countdown. The second commit makes
the button do the same. If the standby timer is disabled, nothing would
count down, so it keeps blanking right away in that case.

Tested on a Rancilio Silvia E (momentary switch).
