### PR TITLE
Run MQTT in its own task, so a stalled link cannot stall the control loop

### DIFF
--- a/src/embeddedWebserver.h
+++ b/src/embeddedWebserver.h
@@ -383,7 +383,10 @@ inline void serverSetup() {
             }
 
             registry.forceSave();
-            writeSysParamsToMQTT(true);
+            // Do not publish from the AsyncWebServer task: PubSubClient is not
+            // thread-safe and writeSysParamsToMQTT() keeps static iterators. Let the
+            // MQTT task publish instead.
+            requestMqttPublish();
 
             AsyncWebServerResponse* response = request->beginResponse(200, "text/plain", hasErrors ? "Partial Success" : "OK");
             response->addHeader("Connection", "close");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -361,6 +361,7 @@ void checkWifi() {
                 LOGF(INFO, "Attempting WIFI (re-)connection: %i", wifiReconnects);
                 wm.disconnect();
                 WiFi.begin();
+                WiFi.setSleep(false); // keep power save off across reconnects
             }
 
             delay(20);                // give WIFI some time to connect
@@ -839,6 +840,15 @@ void wiFiSetup() {
         IPAddress ip = WiFi.localIP();
         snprintf(ipStr, sizeof(ipStr), "%u.%u.%u.%u", ip[0], ip[1], ip[2], ip[3]);
         LOGF(INFO, "WiFi connected - IP = %s", ipStr);
+
+        // Disable WiFi power save. With the Arduino default (WIFI_PS_MIN_MODEM) the ESP
+        // sleeps between DTIM beacons, so the AP buffers packets and round-trip times
+        // climb into the hundreds of milliseconds. Measured on one machine: 446 ms
+        // average with peaks of 1.4 s, while the router itself answered in 3 ms. That is
+        // enough to run MQTT publishes into their socket timeout, which drops the
+        // connection -- the machine then sits offline for minutes and remote commands
+        // are lost. Costs roughly 25 mA, which is nothing next to a 1100 W boiler.
+        WiFi.setSleep(false);
 
         byte mac[6];
         WiFi.macAddress(mac);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -170,6 +170,7 @@ char const* machinestateEnumToString(MachineState machineState);
 inline std::vector<const char*> getMachineStateOptions();
 float filterPressureValue(float input);
 int writeSysParamsToMQTT(bool continueOnError);
+void requestMqttPublish();
 void updateStandbyTimer();
 void resetStandbyTimer();
 void wiFiReset();
@@ -211,6 +212,14 @@ double standbyModeTime = STANDBY_MODE_TIME;
 
 // Variables to hold PID values (Temp input, Heater output)
 double temperature, pidOutput;
+
+// 32-bit snapshots of the 64-bit values the MQTT task publishes. A double is two
+// separate accesses on this core, so a reader on the other core could observe a
+// half-updated value; a float is a single aligned 32-bit access and therefore
+// atomic. The lost precision does not matter -- these are published as "%.2f".
+volatile float mqttTemperature = 0.0f;
+volatile float mqttHeaterPower = 0.0f;
+volatile float mqttBrewTime = 0.0f;
 bool steamON = false;
 bool steamFirstON = false;
 
@@ -898,6 +907,62 @@ void testTimer(void) {
 
 extern const char sysVersion[] = STR(AUTO_VERSION);
 
+// Blocking socket I/O does not belong in the control loop: PubSubClient has a socket
+// timeout (15 s by default), so on a weak link a single publish or connect can stall
+// the main loop for seconds. That freezes temperature sampling, the PID update and the
+// brew timer -- the brew timer visibly sticking and then jumping is how this was found.
+//
+// The ESP32 has two cores: the Arduino loop() runs on core 1 while LWIP/WiFi runs on
+// core 0, so MQTT gets its own task pinned to core 0. This task is then the only place
+// PubSubClient is used, which matters because the library is not thread-safe and
+// writeSysParamsToMQTT() keeps static iterators -- the AsyncWebServer used to call it
+// from its own task, so saving a parameter in the web UI could corrupt them.
+void mqttTask(void* pvParameters) {
+    for (;;) {
+        if (mqtt_enabled && !offlineMode && WiFi.status() == WL_CONNECTED) {
+            // set inside writeSysParamsToMQTT()/sendHASSIODiscoveryMsg() and read by
+            // debugTimingLoop(); the main loop used to clear them
+            mqttUpdateRunning = false;
+            hassioUpdateRunning = false;
+
+            checkMQTT();
+
+            if (mqtt.connected()) {
+                previousMqttConnection = millis();
+
+                // processes incoming messages -> mqtt_callback() -> mqttCmdQueue
+                mqtt.loop();
+
+                // may block on a weak link; the main loop keeps running regardless
+                writeSysParamsToMQTT(true);
+
+                if (mqtt_hassio_enabled && !(machineState >= kBrew && machineState <= kBackflush)) {
+                    if (!mqtt_was_connected) {
+                        // Send discovery as soon as the connection is up -- deliberately
+                        // not via hassioDiscoveryTimer(), which only fires every 300 s and
+                        // therefore delayed the entities by minutes after a boot.
+                        sendHASSIODiscoveryMsg();
+                    }
+                    else if (hassioFailed) {
+                        // Retry a failed send, but rate-limited: this task runs every
+                        // 100 ms and would otherwise hammer the broker.
+                        hassioDiscoveryTimer();
+                    }
+                }
+
+                mqtt_was_connected = true;
+            }
+            // Suppress debug messages until we have a connection established
+            else if (mqtt_was_connected) {
+                LOG(INFO, "MQTT disconnected");
+                mqtt_was_connected = false;
+            }
+        }
+
+        vTaskDelay(pdMS_TO_TICKS(100));
+    }
+}
+
 void setup() {
     // Start serial console
     Serial.begin(115200);
@@ -1072,8 +1137,8 @@ void setup() {
             mqttVars["standbyModeOn"] = "standby.enabled";
 
             // Values reported to MQTT
-            mqttSensors["temperature"] = [] { return temperature; };
-            mqttSensors["heaterPower"] = [] { return pidOutput / 10; };
+            mqttSensors["temperature"] = [] { return static_cast<double>(mqttTemperature); };
+            mqttSensors["heaterPower"] = [] { return static_cast<double>(mqttHeaterPower) / 10; };
             mqttSensors["standbyModeTimeRemaining"] = [] { return standbyModeRemainingTimeMillis / 1000; };
             mqttSensors["currentKp"] = [] { return bPID.GetKp(); };
             mqttSensors["currentKi"] = [] { return bPID.GetKi(); };
@@ -1086,7 +1151,7 @@ void setup() {
                 mqttVars["aggbTv"] = "pid.bd.tv";
                 mqttVars["pidUseBD"] = "pid.bd.enabled";
                 mqttVars["brewPidDelay"] = "brew.pid_delay";
-                mqttSensors["currBrewTime"] = [] { return currBrewTime / 1000; };
+                mqttSensors["currBrewTime"] = [] { return static_cast<double>(mqttBrewTime) / 1000; };
                 mqttVars["targetBrewTime"] = "brew.by_time.target_time";
                 mqttVars["preinfusion"] = "brew.pre_infusion.time";
                 mqttVars["preinfusionPause"] = "brew.pre_infusion.pause";
@@ -1124,10 +1189,34 @@ void setup() {
             mqtt.setServer(mqtt_server_ip.c_str(), mqtt_server_port);
             mqtt.setCallback(mqtt_callback);
 
-            checkMQTT();
+            // PubSubClient defaults to a 15 s socket timeout. 8 s instead: long enough to
+            // ride out a latency spike on a weak link, short enough that an unreachable
+            // broker does not hold publishes for the full default. Going much lower is a
+            // mistake -- at 2 s every spike costs the connection. The keep-alive is raised
+            // so the connection survives a slow pass.
+            mqtt.setSocketTimeout(8);
+            mqtt.setKeepAlive(30);
 
-            if (mqtt_hassio_enabled) {
-                sendHASSIODiscoveryMsg();
+            mqttCmdQueue = xQueueCreate(10, sizeof(MqttCommand));
+
+            if (mqttCmdQueue == nullptr) {
+                LOG(ERROR, "Failed to create MQTT command queue");
+            }
+
+            // No checkMQTT() or sendHASSIODiscoveryMsg() here: both are blocking and
+            // would delay the boot (connect() waits for the socket timeout when the
+            // broker is unreachable), and at this point mqtt.connected() is still false,
+            // so the discovery would be sent into the void anyway. The task does both as
+            // soon as it is up, which also makes it the only user of PubSubClient.
+            if (mqttCmdQueue != nullptr) {
+                xTaskCreatePinnedToCore(mqttTask, "mqtt", 8192, nullptr, 1, &mqttTaskHandle, 0);
+
+                if (mqttTaskHandle == nullptr) {
+                    LOG(ERROR, "Failed to start MQTT task");
+                }
+                else {
+                    LOG(INFO, "MQTT task started on core 0");
+                }
             }
         }
     }
@@ -1261,37 +1350,16 @@ void loopPid() {
         }
 
         if (mqtt_enabled) {
-            mqttUpdateRunning = false;
+            // Hand the 64-bit values to the MQTT task as atomic 32-bit snapshots, so it
+            // can never read one while it is half updated.
+            mqttTemperature = static_cast<float>(temperature);
+            mqttHeaterPower = static_cast<float>(pidOutput);
+            mqttBrewTime = static_cast<float>(currBrewTime);
 
-            if (getSignalStrength() > 1) {
-                checkMQTT();
-
-                // if screen is ready to refresh wait for next loop
-                if (!displayBufferReady && !temperatureUpdateRunning) {
-                    writeSysParamsToMQTT(true); // Continue on error
-                }
-            }
-
-            hassioUpdateRunning = false;
-
-            if (mqtt.connected() == 1) {
-                mqtt.loop();
-                previousMqttConnection = millis();
-
-                if (mqtt_hassio_enabled) {
-                    // resend discovery messages if not during a main function and MQTT has been disconnected but has now reconnected, or if last send failed
-                    if (!(machineState >= kBrew && machineState <= kBackflush) && ((!mqtt_was_connected || hassioFailed) && !displayBufferReady && !temperatureUpdateRunning)) {
-                        hassioDiscoveryTimer();
-                    }
-                }
-
-                mqtt_was_connected = true;
-            }
-            // Supress debug messages until we have a connection etablished
-            else if (mqtt_was_connected) {
-                LOG(INFO, "MQTT disconnected");
-                mqtt_was_connected = false;
-            }
+            // MQTT itself runs in mqttTask() on core 0. The loop only applies the
+            // commands the task received, because assignMQTTParam() writes
+            // ParameterRegistry state, which has to stay on this core.
+            processMqttCommands();
         }
 
         ArduinoOTA.handle(); // For OTA
@@ -1320,7 +1388,7 @@ void loopPid() {
     websiteUpdateRunning = false;
 
     // refresh website if loop does not have anoth long running process already
-    if (((millis() - lastTempEvent) > tempEventInterval) && (!mqttUpdateRunning && !hassioUpdateRunning && !displayBufferReady && !temperatureUpdateRunning)) {
+    if (((millis() - lastTempEvent) > tempEventInterval) && (!displayBufferReady && !temperatureUpdateRunning)) {
         websiteUpdateRunning = true;
 
         // send temperatures to website endpoint
@@ -1391,7 +1459,7 @@ void loopPid() {
     if (u8g2 != nullptr) {
 
         // update display on loops that have not had other major tasks running, if blocked it will send in the next loop (average 0.5ms)
-        if ((!websiteUpdateRunning && !mqttUpdateRunning && !hassioUpdateRunning && !temperatureUpdateRunning) || (millis() - lastDisplayUpdate > 500)) {
+        if ((!websiteUpdateRunning && !temperatureUpdateRunning) || (millis() - lastDisplayUpdate > 500)) {
 
             if (standbyModeRemainingTimeDisplayOffMillis > 0) {
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1199,12 +1199,16 @@ void setup() {
             mqtt.setServer(mqtt_server_ip.c_str(), mqtt_server_port);
             mqtt.setCallback(mqtt_callback);
 
-            // PubSubClient defaults to a 15 s socket timeout. 8 s instead: long enough to
-            // ride out a latency spike on a weak link, short enough that an unreachable
-            // broker does not hold publishes for the full default. Going much lower is a
-            // mistake -- at 2 s every spike costs the connection. The keep-alive is raised
-            // so the connection survives a slow pass.
-            mqtt.setSocketTimeout(8);
+            // Workaround for knolleary/pubsubclient#670: connect() busy-waits for CONNACK
+            // without ever sleeping, so the idle task on this core never runs. This task
+            // is pinned to core 0, whose idle task is watchdog-checked, so a silent broker
+            // aborts the firmware. The socket timeout is the only bound on that spin and
+            // must stay below the watchdog. yield() would not help -- it picks the highest
+            // ready priority, and this task outranks idle.
+            static constexpr int mqttSocketTimeoutS = 3;
+            static_assert(mqttSocketTimeoutS < CONFIG_ESP_TASK_WDT_TIMEOUT_S,
+                          "MQTT socket timeout must stay below the core 0 task watchdog");
+            mqtt.setSocketTimeout(mqttSocketTimeoutS);
             mqtt.setKeepAlive(30);
 
             mqttCmdQueue = xQueueCreate(10, sizeof(MqttCommand));

--- a/src/mqtt.h
+++ b/src/mqtt.h
@@ -74,11 +74,24 @@ inline void setupMqtt() {
 }
 
 /**
- * @brief Check if MQTT is connected, if not reconnect. Abort function if offline or brew is running
+ * @brief Ask the MQTT task to publish on its next pass instead of publishing here.
+ *
+ * Callers outside the MQTT task (e.g. the AsyncWebServer) must not touch PubSubClient.
+ * Clearing the rate-limit stamp makes the task publish on its next pass.
+ */
+inline void requestMqttPublish() {
+    previousMillisMQTT = 0;
+}
+
+/**
+ * @brief Check if MQTT is connected, if not reconnect. Abort function if offline
  *      MQTT is also using maxWifiReconnects!
  */
 inline void checkMQTT() {
-    if (offlineMode || checkBrewActive()) {
+    // No brew guard needed anymore: it only existed because mqtt.connect() is
+    // blocking and would have stalled the main loop during a shot. This runs in
+    // the MQTT task now, so reconnecting mid-shot does not affect the loop.
+    if (offlineMode) {
         return;
     }
 
@@ -239,6 +252,20 @@ inline void assignMQTTParam(char* param, double value) {
     }
 }
 
+// Incoming MQTT commands are handed to the main loop through this queue rather than
+// being applied in the MQTT task: mqtt.loop() invokes mqtt_callback() in the task's
+// context, and assignMQTTParam() writes ParameterRegistry state from there, which must
+// not happen concurrently with the main loop reading it. Outgoing telemetry is fine to
+// read directly from the task -- those are plain numbers, published rounded and only on
+// change, so a torn read would at worst be a single wrong displayed value.
+struct MqttCommand {
+        char param[120];
+        double value;
+};
+
+inline QueueHandle_t mqttCmdQueue = nullptr;
+inline TaskHandle_t mqttTaskHandle = nullptr;
+
 /**
  * @brief MQTT Callback Function: set Parameters through MQTT
  */
@@ -265,7 +292,37 @@ inline void mqtt_callback(const char* topic, const byte* data, const unsigned in
 
     // convert received string value to double assuming it's a number
     sscanf(data_str, "%lf", &data_double);
-    assignMQTTParam(configVar, data_double);
+
+    // Runs in the MQTT task -> hand the command over to the main loop instead of
+    // writing ParameterRegistry state here. Timeout 0, so this never blocks.
+    if (mqttCmdQueue != nullptr) {
+        MqttCommand cmd_msg;
+        snprintf(cmd_msg.param, sizeof(cmd_msg.param), "%s", configVar);
+        cmd_msg.value = data_double;
+
+        if (xQueueSend(mqttCmdQueue, &cmd_msg, 0) != pdTRUE) {
+            LOGF(WARNING, "MQTT command queue full, dropped: %s", configVar);
+        }
+    }
+    else {
+        // Queue not created (task not running) -- apply directly
+        assignMQTTParam(configVar, data_double);
+    }
+}
+
+/**
+ * @brief Apply the MQTT commands received by the task. Must be called from the main loop.
+ */
+inline void processMqttCommands() {
+    if (mqttCmdQueue == nullptr) {
+        return;
+    }
+
+    MqttCommand cmd_msg;
+
+    while (xQueueReceive(mqttCmdQueue, &cmd_msg, 0) == pdTRUE) {
+        assignMQTTParam(cmd_msg.param, cmd_msg.value);
+    }
 }
 
 /**

--- a/src/mqtt.h
+++ b/src/mqtt.h
@@ -20,7 +20,6 @@ inline unsigned long previousMillisMQTT;
 const unsigned long intervalMQTT = 5000;
 const unsigned long intervalMQTTbrew = 500;
 const unsigned long intervalMQTTstandby = 10000;
-unsigned long timeBudget = 10; // milliseconds per loop until all data is sent
 
 inline WiFiClient net;
 inline PubSubClient mqtt(net);
@@ -333,9 +332,8 @@ inline void processMqttCommands() {
  */
 
 inline int writeSysParamsToMQTT(const bool continueOnError = true) {
-    static auto mqttVarsIt = mqttVars.begin();
-    static auto mqttSensorsIt = mqttSensors.begin();
-    static bool inSensors = false;
+    auto mqttVarsIt = mqttVars.begin();
+    auto mqttSensorsIt = mqttSensors.begin();
 
     unsigned long currentMillisMQTT = millis();
     unsigned long interval = (machineState == kBrew) ? intervalMQTTbrew : (machineState == kStandby) ? intervalMQTTstandby : intervalMQTT;
@@ -344,94 +342,80 @@ inline int writeSysParamsToMQTT(const bool continueOnError = true) {
         return 0;
     }
 
-    if (!inSensors && mqttVarsIt == mqttVars.begin()) {
-        previousMillisMQTT = currentMillisMQTT;
-        mqtt_publish("status", (char*)"online");
-    }
+    previousMillisMQTT = currentMillisMQTT;
+    mqtt_publish("status", (char*)"online");
 
     mqttUpdateRunning = true;
-    unsigned long start = millis();
 
     char data[12];
     int errorState = 0;
     auto& registry = ParameterRegistry::getInstance();
 
-    if (!inSensors) {
-        // Iterate through the mqttVars mapping to publish parameters
-        while (mqttVarsIt != mqttVars.end()) {
-            const char* mqttTopic = mqttVarsIt->first;
-            const char* parameterId = mqttVarsIt->second;
+    // Iterate through the mqttVars mapping to publish parameters
+    while (mqttVarsIt != mqttVars.end()) {
+        const char* mqttTopic = mqttVarsIt->first;
+        const char* parameterId = mqttVarsIt->second;
 
-            std::shared_ptr<Parameter> param = registry.getParameterById(parameterId);
+        std::shared_ptr<Parameter> param = registry.getParameterById(parameterId);
 
-            if (param == nullptr) {
+        if (param == nullptr) {
+            if (!continueOnError) {
+                LOGF(ERROR, "Parameter %s not found for MQTT topic %s", parameterId, mqttTopic);
+                return 1;
+            }
+
+            LOGF(WARNING, "Parameter %s not found for MQTT topic %s, skipping", parameterId, mqttTopic);
+            ++mqttVarsIt;
+            continue;
+        }
+
+        // Get value based on parameter type and format as string
+        switch (param->getType()) {
+            case kInteger:
+                snprintf(data, sizeof(data), "%d", param->getValueAs<int>());
+                break;
+            case kUInt8:
+                snprintf(data, sizeof(data), "%u", param->getValueAs<uint8_t>());
+                break;
+            case kDouble:
+                snprintf(data, sizeof(data), "%.2f", param->getValueAs<double>());
+                break;
+            case kFloat:
+                snprintf(data, sizeof(data), "%.2f", param->getValueAs<float>());
+                break;
+            case kCString:
+                snprintf(data, sizeof(data), "%s", param->getValueAs<String>().c_str());
+                break;
+            default:
+
                 if (!continueOnError) {
-                    LOGF(ERROR, "Parameter %s not found for MQTT topic %s", parameterId, mqttTopic);
+                    LOGF(ERROR, "Unknown parameter type for topic %s", mqttTopic);
                     return 1;
                 }
 
-                LOGF(WARNING, "Parameter %s not found for MQTT topic %s, skipping", parameterId, mqttTopic);
+                LOGF(WARNING, "Skipping unknown parameter type for topic %s", mqttTopic);
                 ++mqttVarsIt;
                 continue;
-            }
+        }
 
-            // Get value based on parameter type and format as string
-            switch (param->getType()) {
-                case kInteger:
-                    snprintf(data, sizeof(data), "%d", param->getValueAs<int>());
-                    break;
-                case kUInt8:
-                    snprintf(data, sizeof(data), "%u", param->getValueAs<uint8_t>());
-                    break;
-                case kDouble:
-                    snprintf(data, sizeof(data), "%.2f", param->getValueAs<double>());
-                    break;
-                case kFloat:
-                    snprintf(data, sizeof(data), "%.2f", param->getValueAs<float>());
-                    break;
-                case kCString:
-                    snprintf(data, sizeof(data), "%s", param->getValueAs<String>().c_str());
-                    break;
-                default:
+        if (mqttLastSent[mqttTopic].compare(data) != 0) {
+            if (!mqtt_publish(mqttTopic, data, true)) {
+                errorState = mqtt.state();
 
-                    if (!continueOnError) {
-                        LOGF(ERROR, "Unknown parameter type for topic %s", mqttTopic);
-                        return 1;
-                    }
-
-                    LOGF(WARNING, "Skipping unknown parameter type for topic %s", mqttTopic);
-                    ++mqttVarsIt;
-                    continue;
-            }
-
-            if (mqttLastSent[mqttTopic].compare(data) != 0) {
-                if (!mqtt_publish(mqttTopic, data, true)) {
-                    errorState = mqtt.state();
-
-                    if (!continueOnError) {
-                        LOGF(ERROR, "Failed to publish parameter %s to MQTT, error: %d", mqttTopic, errorState);
-                        return errorState;
-                    }
-
-                    LOGF(WARNING, "Failed to publish parameter %s to MQTT, error: %d", mqttTopic, errorState);
+                if (!continueOnError) {
+                    LOGF(ERROR, "Failed to publish parameter %s to MQTT, error: %d", mqttTopic, errorState);
+                    return errorState;
                 }
-                else {
-                    mqttLastSent[mqttTopic].assign(data); // Update only if sent successfully
-                    LOGF(DEBUG, "Published %s = %s to MQTT, length: %i", mqttTopic, data, strlen(data) + 1);
-                }
+
+                LOGF(WARNING, "Failed to publish parameter %s to MQTT, error: %d", mqttTopic, errorState);
             }
-
-            ++mqttVarsIt;
-
-            // Return early, continue next time
-            if (millis() - start >= timeBudget) {
-                return 0;
+            else {
+                mqttLastSent[mqttTopic].assign(data); // Update only if sent successfully
+                LOGF(DEBUG, "Published %s = %s to MQTT, length: %i", mqttTopic, data, strlen(data) + 1);
             }
         }
 
-        // Done with mqttVars, start sensors
-        mqttVarsIt = mqttVars.begin();
-        inSensors = true;
+        ++mqttVarsIt;
     }
 
     while (mqttSensorsIt != mqttSensors.end()) {
@@ -462,15 +446,7 @@ inline int writeSysParamsToMQTT(const bool continueOnError = true) {
         }
 
         ++mqttSensorsIt;
-
-        if (millis() - start >= timeBudget) {
-            return 0; // Return early, continue next time
-        }
     }
-
-    // Done with both loops
-    mqttSensorsIt = mqttSensors.begin();
-    inSensors = false;
 
     return 0;
 }


### PR DESCRIPTION
Three related changes to how MQTT behaves on a weak WiFi link. They build on each
other but are separate commits and can be taken individually.

## Why

**1. MQTT never connects below -75 dBm, and nothing says why.**
`loopPid()` gates the MQTT work behind `if (getSignalStrength() > 1)`, and
`getSignalStrength()` returns 0 below -80 dBm, so `checkMQTT()` is never called.
The gate sits before every log statement, so no message appears at any log level:
from the outside MQTT is simply broken and undiagnosable. An ESP mounted inside a
machine's metal body sits at that level routinely — mine is at a constant -85 to
-88 dBm, while OTA updates (1.5 MB), the web UI and the telnet logger all work
fine over that same link.

**2. `writeSysParamsToMQTT()` is called from two tasks — already, without this change.**
Once from `loopPid()`, and once from `embeddedWebserver.h` when a parameter is
saved. Those run in two different FreeRTOS tasks: the Arduino loop task at
priority 1, and AsyncTCP's service task at priority 10
(`CONFIG_ASYNC_TCP_PRIORITY`), pinned to no particular core
(`CONFIG_ASYNC_TCP_RUNNING_CORE = -1`). Since FreeRTOS schedules preemptively,
the web handler interrupts the loop as soon as a request arrives — mid-iteration,
and whichever core each task happens to run on. Two tasks are enough for this; it
does not require two cores.

PubSubClient is not thread-safe, and the function kept static iterators across
calls:

    static auto mqttVarsIt = mqttVars.begin();
    static auto mqttSensorsIt = mqttSensors.begin();

Saving a parameter in the web UI could therefore corrupt an iteration the main
loop was in the middle of. This is independent of link quality or configuration.

**3. Blocking socket I/O sits in the control loop.**
`mqtt.connect()` is blocking — the code says so itself ("connect() is a blocking
function, watch the timeout!") — and PubSubClient's socket timeout defaults to
15 s. A broker that stops answering stalls `loopPid()` for seconds, which halts
temperature sampling, PID updates and the brew timer. No weak link is needed for
that; an unreachable broker on a perfectly good link is enough. That the loop is
sensitive to this is already acknowledged in two places: `checkMQTT()` returns
early during a brew, and the discovery resend is skipped between `kBrew` and
`kBackflush`. Both are targeted workarounds.

The gate from (1) is really a workaround for (3): it wraps exactly the two
blocking calls, while the non-blocking `mqtt.loop()` sits outside it. Deleting it
on its own is not a fix — I measured that: with the gate gone but MQTT still in
the loop, a publish ran into the socket timeout and the brew timer visibly stuck
before jumping. The blocking work has to leave the loop first.

## What changed

MQTT moves into its own FreeRTOS task pinned to core 0 (the Arduino loop runs on
core 1, LWIP/WiFi on core 0), and that task becomes the only place PubSubClient is
touched. The two directions are treated differently:

- **outgoing:** the loop hands values over as 32-bit snapshots. Most are 32-bit
  already; `temperature`, `pidOutput` and `currBrewTime` are doubles, i.e. two
  accesses on this core, so the loop keeps float copies. They are published as
  `"%.2f"` anyway, so no precision that matters is lost.
- **incoming:** `mqtt.loop()` invokes `mqtt_callback()` in the task's context, and
  `assignMQTTParam()` writes ParameterRegistry state from there. Those go through
  a FreeRTOS queue back to core 1, where `processMqttCommands()` applies them, so
  every write stays on core 1.

The blocking `checkMQTT()` and `sendHASSIODiscoveryMsg()` calls at the end of
`setup()` are gone: they delayed the boot for as long as the socket timeout, and
they ran before the connection existed, so the discovery went nowhere and had to
be repeated by the 300 s timer anyway. The task now sends it the moment the
connection comes up — entities appear about 15 s after boot instead of ~90 s.

Commit 2 disables WiFi power save, which turned out to be the root cause of the
latency that ran publishes into their timeouts. Latency compounds per round trip:
a publish cycle is 44 topics in about two TCP segments, but before that come the
TCP handshake and CONNECT/CONNACK — several round trips before a single value is
on the wire. At 446 ms RTT that is more than a second just to get connected, and
no amount of coalescing helps against it.

Commit 3 removes the 10 ms time budget from `writeSysParamsToMQTT()`; it only
existed to keep the function from dwelling in the loop, and removing it takes the
static iterators from (2) with it — the function no longer carries anything across
calls. It also stops defeating Nagle: chunked across task passes 100 ms apart,
nothing can be coalesced and every chunk pays for its own segment.

Also in this change: `setSocketTimeout(8)` instead of the 15 s default and
`setKeepAlive(30)`; the `checkBrewActive()` guard in `checkMQTT()` is gone (it
only existed to protect the loop); and `mqttUpdateRunning`/`hassioUpdateRunning`
are no longer part of the display and temperature-event conditions, since waiting
on them gains nothing once MQTT is on another core.

## Measurements

Latency on the same link, before and after `WiFi.setSleep(false)` (min/avg/max):

| | |
|---|---|
| router in the same network | 2.0 / 4.1 / 5.5 ms |
| ESP32, power save on (default) | 42.5 / **445.8** / 1410.1 ms |
| ESP32, power save off | 8.4 / **49.8** / 285.1 ms |

No packet loss in either case — purely latency, and it originates in the ESP.

TCP segments for one publish cycle (44 topics, 1877 bytes), counted via
`getsockopt(TCP_INFO).tcpi_segs_in` on the same board type this firmware runs on:

| | segments (3 runs) |
|---|---|
| written back to back | 5, 5, 5 |
| chunked into 100 ms slices | 23, 21, 22 |

Identical payload; the five break down as two data segments (1877 bytes at an MSS
of 1460) plus connect and disconnect.

Verified on a Rancilio Silvia E whose ESP sits at a constant -85 to -88 dBm inside
the machine's metal body: MQTT connects and stays connected — zero dropouts over a
night, against 14 the night before, four of them longer than ten minutes. Commands
arrive through the queue, the PID keeps regulating, the web UI stays responsive,
and the machine still boots as configured.

The brew timer is worth one sentence, because the loop increments it: it counted up
smoothly, on the display and in the published values, and it did so through a
stretch where transmission stalled for twelve seconds — the task absorbed that, the
loop never noticed, no value was lost.

## Note on scope

Commit 2 (`WiFi.setSleep(false)`) is independent of the task and helps OTA and the
web UI just as much — happy to split it into its own PR if you prefer. Commit 1 is
the architectural one; it introduces the first FreeRTOS task in the project.
