### PR TITLE
Don't switch to offline mode permanently while running

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -377,8 +377,19 @@ void checkWifi() {
     }
 
     if (wifiReconnects >= maxWifiReconnects && WiFi.status() != WL_CONNECTED) {
-        // no wifi connection after trying connection, initiate offline mode
-        initOfflineMode();
+        // Deliberately not initOfflineMode() here. That call belongs to startup -- as
+        // the comment on the function itself says -- and it is not reversible: it sets
+        // mqtt_enabled = false, brings up a SoftAP, and nothing ever clears offlineMode
+        // again. checkWifi() returns immediately while offlineMode is set, so a
+        // returning connection is never even noticed.
+        //
+        // With 5 attempts at 10 s apart, roughly a minute of interference was therefore
+        // enough to lose MQTT until the next reboot, on a machine that had long since
+        // reconnected. Pause and start a fresh round of attempts instead.
+        LOGF(INFO, "WiFi still down after %i attempts, pausing before the next round", wifiReconnects);
+        wifiReconnects = 0;
+        wifiConnectCounter = 1; // so the next round actually issues WiFi.begin() again
+        lastWifiConnectionAttempt = millis();
     }
     else {
         if (WiFi.status() == WL_CONNECTED) {


### PR DESCRIPTION
## Problem

`checkWifi()` calls `initOfflineMode()` after `maxWifiReconnects` failed attempts. That call belongs to startup (the comment on the function says so itself), but `checkWifi()` runs from `loopPid()`, so it also fires during normal operation.

And it cannot be undone:

```cpp
offlineMode = true;
mqtt_enabled = false;
mqtt_hassio_enabled = false;
WiFi.softAP(hostname.c_str(), pass);
```

`offlineMode` is only ever assigned there, and `checkWifi()` returns early while it is set, so a returning connection is never noticed. With `MAXWIFIRECONNECTS = 5` and `WIFICONNECTIONDELAY = 10000`, about a minute of interference costs MQTT until the next reboot. It also locks out `ArduinoOTA.handle()`, which sits in the same `!offlineMode` block, so you cannot even update the machine remotely to fix it.

## How I ran into this

The WiFi in my kitchen is a bit flaky sometimes and one night it dropped a few times. By morning MQTT was gone for good, while the machine was perfectly reachable over the same network. Ping answered in 20 ms, the web UI responded, and a WiFi scan showed the machine's own access point next to my router's.

The MQTT task was alive the whole time, just short-circuited by the flag, so it logged nothing either. I got the machine back with a `POST /restart`. The web server survives that state because it runs in the AsyncTCP task and never looks at `offlineMode`.

## Fix

Pause and start a fresh round of attempts instead of giving up for good. `wifiConnectCounter` is reset along with `wifiReconnects`, because that counter drives the retry cycle. Without it the round after the pause runs through without issuing `WiFi.begin()`.

Startup behaviour is unchanged. The two `initOfflineMode()` calls in `wiFiSetup()` and `setup()` still apply when there is no WiFi to begin with, which is what the offline AP is for.
