### PR TITLE
Pre-size the response buffers for /parameters and /timeseries

### DIFF
--- a/src/embeddedWebserver.h
+++ b/src/embeddedWebserver.h
@@ -290,7 +290,29 @@ inline void serverSetup() {
                 limit = request->getParam("limit")->value().toInt();
             }
 
-            AsyncResponseStream* response = request->beginResponseStream("application/json");
+            // Asking for more than the registry holds cannot return more, and the
+            // response buffer below is sized from this value -- so clamp it.
+            if (limit > static_cast<int>(parameters.size())) {
+                limit = static_cast<int>(parameters.size());
+            }
+
+            if (limit < 0) {
+                limit = 0;
+            }
+
+            // Pre-size the buffer. cbuf::resizeAdd() grows by exactly the number of
+            // missing bytes, so once the buffer is full every further character
+            // reallocates the whole thing and copies it: a large response means
+            // thousands of allocations of steadily increasing size and tens of
+            // megabytes of memcpy. That fragments the heap badly enough that a
+            // several-kilobyte allocation fails even with plenty of free heap, and
+            // since operator new throws here rather than returning null, the failure
+            // aborts instead of being caught by cbuf's null check.
+            //
+            // A generous estimate per parameter; if it is still too small the old
+            // grow-by-one behaviour just resumes for the remainder, so erring high
+            // costs a little RAM for the duration of the request and nothing else.
+            AsyncResponseStream* response = request->beginResponseStream("application/json", limit * 384 + 256);
             response->print("{\"parameters\":[");
 
             bool first = true;
@@ -437,7 +459,13 @@ inline void serverSetup() {
     });
 
     server.on("/timeseries", HTTP_GET, [](AsyncWebServerRequest* request) {
-        AsyncResponseStream* response = request->beginResponseStream("application/json");
+        // Three arrays of HISTORY_LENGTH values, each at most seven characters plus a
+        // separator, plus the keys. Sizing this up front matters: see the comment on
+        // the buffer in /parameters -- writing ~11 kB one character at a time into the
+        // default 1460-byte buffer reallocates roughly 9000 times and was crashing
+        // machines whose web UI was left open, because the chart polls this endpoint.
+        constexpr size_t timeseriesBufferSize = 3 * HISTORY_LENGTH * 8 + 64;
+        AsyncResponseStream* response = request->beginResponseStream("application/json", timeseriesBufferSize);
         response->addHeader("Connection", "close"); // Force connection close
 
         response->print('{');


### PR DESCRIPTION
## Problem

`/parameters` and `/timeseries` write their JSON into an `AsyncResponseStream` one value at a time, using the default 1460-byte buffer. `cbuf::resizeAdd()` grows by exactly the number of missing bytes, so once that buffer is full, every further character allocates a new buffer, copies the whole content over and frees the old one. For `/timeseries` that is around 9000 reallocations for a single request.

The churn fragments the heap until an allocation of a few kilobytes fails while tens of kilobytes are still free. And because `operator new` throws here instead of returning null, the `if(!newbuf)` check in `cbuf::resize()` never runs, so the failure aborts the firmware rather than being handled.

## How I ran into it

Three panics on my machine within a day, all in the `async_tcp` task. The core dump showed `operator new[](6649)` failing inside `cbuf::resize()` while serving `/timeseries`:

```
#7  operator new[] (sz=6649)
#8  cbuf::resize (newSize=6649)                    cbuf.cpp:49
#9  cbuf::resizeAdd (addSize=1)                    cbuf.cpp:35
#10 AsyncResponseStream::write (len=1, data="4")   WebResponses.cpp:914
#19 Print::print (n=7.49, digits=2)
#20 serverSetup()::{lambda(AsyncWebServerRequest*)#9}
```

The trigger turned out to be a browser tab I had left open on the web UI, since the chart polls that endpoint. Nothing was leaking: free heap and largest free block were stable the whole time (63 to 68 kB, and 45 to 51 kB). It is a transient allocation failure, created by the request itself.

## Fix

Size the buffer up front, so it is one allocation taken at the start of the request when the heap is least fragmented.

`/timeseries` derives its size from `HISTORY_LENGTH` rather than a fixed number, so it stays correct if someone raises it. `/parameters` is sized from the requested `limit`, which is now also clamped to the number of parameters that exist, since asking for more cannot return more. `/temperatures` is left alone, it writes three floats and never outgrows the default buffer.

Costs 40 bytes of flash.

## Reproducing it

```
GET /parameters?filter=all&limit=200
```

On my board that crashed the firmware on the second request. With the patch, 8 out of 8 requests returned 200, and so did 8 out of 8 on `/timeseries`. The clearest signal is `esp_reset_reason()`: without the patch it flips to `ESP_RST_PANIC`, with the patch it stayed unchanged across all requests. The large response also went from crashing to 0.16 s.

## Why pre-sizing and not chunked streaming

The peak requirement was never the problem, 12 kB out of 47 kB free would have been fine. The problem is the thousands of reallocations that fragment the heap during the request.

Chunked streaming would be nicer in principle, since memory use would be constant and independent of `HISTORY_LENGTH`. But the callback has to resume at an arbitrary byte offset, across three arrays, 600 indices and possibly in the middle of a formatted number. That is a lot more code and a lot more to get wrong, so it seemed better as a separate change.
