### PR TITLE
Bugfix: Compare device_class by content, not by pointer

### DIFF
--- a/src/mqtt.h
+++ b/src/mqtt.h
@@ -539,7 +539,11 @@ inline DiscoveryObject GenerateSensorDevice(const char* name, const char* displa
     snprintf(topic_buffer, sizeof(topic_buffer), "%s-%s", unique_id, name);
     sensorConfigDoc["unique_id"] = String(topic_buffer);
 
-    if (device_class != "enum") {
+    // Enum sensors must not carry a unit_of_measurement -- HA rejects that combination.
+    // Compare the contents: device_class is a const char*, so != "enum" compared the
+    // pointers, which only happened to work because the caller passes the identical
+    // literal from the same translation unit and the compiler pools those.
+    if (device_class == nullptr || strcmp(device_class, "enum") != 0) {
         sensorConfigDoc["unit_of_measurement"] = unit_of_measurement;
     }
 


### PR DESCRIPTION
The guard that keeps unit_of_measurement off enum sensors reads

    if (device_class != "enum")

which compares addresses, not contents, since device_class is a const char*. It happens to work today only because every caller passes the identical literal from the same translation unit and the compiler pools those. Move a call site elsewhere or pass a runtime string and the comparison silently stops matching, at which point the enum sensor goes out with an empty unit_of_measurement and Home Assistant drops it.

Use strcmp(), treating a null device_class as "not enum" so a sensor without one can still carry a unit.