### PR TITLE
Improved diagnostics via MQTT and Coredump download via HTTP

### DIFF
--- a/src/embeddedWebserver.h
+++ b/src/embeddedWebserver.h
@@ -18,6 +18,8 @@
 #include <ESPAsyncWebServer.h>
 
 #include "LittleFS.h"
+#include <esp_core_dump.h>
+#include <esp_partition.h>
 
 inline AsyncWebServer server(80);
 inline AsyncEventSource events("/events");
@@ -528,6 +530,58 @@ inline void serverSetup() {
         AsyncWebServerResponse* response = request->beginResponse(200, "application/json", prettifiedJson);
         response->addHeader("Content-Disposition", "attachment; filename=\"config.json\"");
         request->send(response);
+    });
+
+    // Hand out the raw core dump the panic handler stored in flash, for offline
+    // analysis with esp-coredump/gdb. The MQTT summary only carries task, cause and
+    // PC; the interesting part -- the full backtrace of every task, plus registers --
+    // is in here. Without this endpoint the only way to it is a serial cable, which
+    // on a built-in board means taking the machine apart.
+    //
+    // Gated by authenticate(), same as the config download.
+    server.on("/download/coredump", HTTP_GET, [](AsyncWebServerRequest* request) {
+        if (!authenticate(request)) {
+            return request->requestAuthentication();
+        }
+
+#if CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH
+        size_t dumpAddr = 0;
+        size_t dumpSize = 0;
+
+        if (esp_core_dump_image_get(&dumpAddr, &dumpSize) != ESP_OK || dumpSize == 0) {
+            request->send(404, "text/plain", "No core dump stored");
+            return;
+        }
+
+        const esp_partition_t* part = esp_partition_find_first(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_DATA_COREDUMP, nullptr);
+
+        if (part == nullptr) {
+            request->send(500, "text/plain", "No coredump partition");
+            return;
+        }
+
+        LOGF(INFO, "Serving core dump, %u bytes", static_cast<unsigned>(dumpSize));
+
+        // Chunked, because the dump is far larger than anything we can hold in RAM.
+        AsyncWebServerResponse* response = request->beginChunkedResponse("application/octet-stream", [part, dumpSize](uint8_t* buffer, size_t maxLen, size_t index) -> size_t {
+            if (index >= dumpSize) {
+                return 0;
+            }
+
+            const size_t chunk = maxLen < (dumpSize - index) ? maxLen : (dumpSize - index);
+
+            if (esp_partition_read(part, index, buffer, chunk) != ESP_OK) {
+                return 0;
+            }
+
+            return chunk;
+        });
+
+        response->addHeader("Content-Disposition", "attachment; filename=\"coredump.bin\"");
+        request->send(response);
+#else
+        request->send(501, "text/plain", "Core dump to flash is not enabled in this build");
+#endif
     });
 
     server.on(

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1130,6 +1130,10 @@ void setup() {
             mqttSensors["currentKi"] = [] { return bPID.GetKi(); };
             mqttSensors["currentKd"] = [] { return bPID.GetKd(); };
             mqttSensors["machineState"] = [] { return machineState; };
+            // Link quality is useful to have in HA: the ESP often sits inside the
+            // machine's metal body, where the signal can be marginal, and dropouts
+            // are otherwise hard to tell apart from other MQTT problems.
+            mqttSensors["rssi"] = [] { return (double)WiFi.RSSI(); };
 
             // Same two values ESPHome's debug component exposes: total free heap plus the
             // largest allocatable block. The pair is what makes a leak diagnosable -- free

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1131,6 +1131,15 @@ void setup() {
             mqttSensors["currentKd"] = [] { return bPID.GetKd(); };
             mqttSensors["machineState"] = [] { return machineState; };
 
+            // Same two values ESPHome's debug component exposes: total free heap plus the
+            // largest allocatable block. The pair is what makes a leak diagnosable -- free
+            // heap alone falls under fragmentation too, while a shrinking largest block at
+            // constant free heap points at fragmentation rather than a leak. Until now
+            // these only went to the telnet log, which keeps no backlog and is therefore
+            // gone exactly when it would be needed.
+            mqttSensors["freeHeap"] = [] { return (double)ESP.getFreeHeap(); };
+            mqttSensors["maxAllocHeap"] = [] { return (double)heap_caps_get_largest_free_block(MALLOC_CAP_DEFAULT); };
+
             if (config.get<bool>("hardware.switches.brew.enabled")) {
                 mqttVars["aggbKp"] = "pid.bd.kp";
                 mqttVars["aggbTn"] = "pid.bd.tn";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -168,6 +168,7 @@ void loopLED();
 void checkWaterTank();
 void printMachineState();
 char const* machinestateEnumToString(MachineState machineState);
+const char* bootResetReasonString();
 inline std::vector<const char*> getMachineStateOptions();
 float filterPressureValue(float input);
 int writeSysParamsToMQTT(bool continueOnError);
@@ -906,7 +907,12 @@ extern const char sysVersion[] = STR(AUTO_VERSION);
  * spontaneous reboot nearly impossible to tell apart from a crash, a watchdog
  * or a brownout after the fact.
  */
-static const char* resetReasonToString(const esp_reset_reason_t reason) {
+// Kept so it can be published once MQTT is up: the log line alone is unreachable,
+// because the telnet logger only serves an already-connected client and keeps no
+// backlog -- by the time anyone can connect, the boot message is long gone.
+esp_reset_reason_t bootResetReason = ESP_RST_UNKNOWN;
+
+const char* resetReasonToString(const esp_reset_reason_t reason) {
     switch (reason) {
         case ESP_RST_POWERON:
             return "power-on";
@@ -933,6 +939,13 @@ static const char* resetReasonToString(const esp_reset_reason_t reason) {
     }
 }
 
+/**
+ * @brief Reset reason of this boot, as text -- published once MQTT is up
+ */
+const char* bootResetReasonString() {
+    return resetReasonToString(bootResetReason);
+}
+
 void setup() {
     // Start serial console
     Serial.begin(115200);
@@ -940,7 +953,8 @@ void setup() {
     // Initialize the logger
     Logger::init(23);
 
-    LOGF(INFO, "Reset reason: %s", resetReasonToString(esp_reset_reason()));
+    bootResetReason = esp_reset_reason();
+    LOGF(INFO, "Reset reason: %s", resetReasonToString(bootResetReason));
 
     if (!config.begin()) {
         LOG(ERROR, "Failed to load config from filesystem!");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,6 +16,7 @@
 #include <PID_v1.h>  // for PID calculation
 #include <U8g2lib.h> // i2c display
 #include <WiFiManager.h>
+#include <esp_core_dump.h>
 #include <esp_system.h>
 #include <os.h>
 
@@ -176,6 +177,7 @@ void checkWaterTank();
 void printMachineState();
 char const* machinestateEnumToString(MachineState machineState);
 const char* bootResetReasonString();
+const char* bootCrashInfoString();
 inline std::vector<const char*> getMachineStateOptions();
 float filterPressureValue(float input);
 int writeSysParamsToMQTT(bool continueOnError);
@@ -953,6 +955,61 @@ const char* bootResetReasonString() {
     return resetReasonToString(bootResetReason);
 }
 
+// Panic details, read back from the core dump the panic handler wrote to flash.
+// On an installed machine the serial console is not reachable -- the board sits
+// inside the case -- so the backtrace that a panic normally prints is lost. The
+// partition table already reserves a coredump partition and the Arduino sdkconfig
+// enables CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH, so the data is there; it just was
+// never read back. Kept short on purpose: the MQTT packet limit is 256 bytes.
+char bootCrashInfo[176] = "";
+
+/**
+ * @brief Read the stored core dump summary into bootCrashInfo, if there is one
+ *
+ * Deliberately not erasing the dump afterwards, so it survives reboots and can be
+ * re-read after an update. That also means the value describes the last panic, not
+ * necessarily the last boot -- pair it with the reset reason to tell them apart.
+ */
+void readCoreDumpSummary() {
+#if CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH && CONFIG_ESP_COREDUMP_DATA_FORMAT_ELF
+    if (esp_core_dump_image_check() != ESP_OK) {
+        // no dump stored, or its checksum does not match
+        return;
+    }
+
+    auto* summary = static_cast<esp_core_dump_summary_t*>(malloc(sizeof(esp_core_dump_summary_t)));
+
+    if (summary == nullptr) {
+        LOG(WARNING, "Not enough memory to read the core dump summary");
+        return;
+    }
+
+    if (esp_core_dump_get_summary(summary) == ESP_OK) {
+        // Task, cause and PC only -- deliberately no backtrace. The summary API caps
+        // it at 16 frames anyway, and an abort() (failed allocation, assert) burns the
+        // first eight on panic_abort/abort/__cxa_throw before anything useful appears,
+        // so a payload-sized excerpt is unreliable by construction. This is triage:
+        // which task died and roughly why. The full dump is available over HTTP.
+        snprintf(bootCrashInfo, sizeof(bootCrashInfo), "task=%s cause=%u pc=0x%08x vaddr=0x%08x", summary->exc_task, static_cast<unsigned>(summary->ex_info.exc_cause), static_cast<unsigned>(summary->exc_pc),
+                 static_cast<unsigned>(summary->ex_info.exc_vaddr));
+
+        LOGF(INFO, "Core dump found: %s", bootCrashInfo);
+    }
+    else {
+        LOG(WARNING, "Core dump present but the summary could not be read");
+    }
+
+    free(summary);
+#endif
+}
+
+/**
+ * @brief Panic details of the last stored core dump, as text
+ */
+const char* bootCrashInfoString() {
+    return bootCrashInfo[0] != '\0' ? bootCrashInfo : "none";
+}
+
 void setup() {
     // Start serial console
     Serial.begin(115200);
@@ -962,6 +1019,8 @@ void setup() {
 
     bootResetReason = esp_reset_reason();
     LOGF(INFO, "Reset reason: %s", resetReasonToString(bootResetReason));
+
+    readCoreDumpSummary();
 
     if (!config.begin()) {
         LOG(ERROR, "Failed to load config from filesystem!");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -119,6 +119,13 @@ unsigned long previousMillisPressure; // initialisation at the end of init()
 
 // timing flags
 bool timingDebugActive = false;
+
+// Worst-case duration of a single main loop pass, in milliseconds. Diagnostic for
+// loop stalls: anything blocking in the loop (network I/O, flash writes) shows up
+// here as a spike. debugTimingLoop() already measures the loop, but only while
+// timingDebugActive is set and only into the telnet log, which is gone after a
+// reboot. Read-and-reset on publish, so each value is the peak since the last one.
+volatile unsigned long maxLoopTime = 0;
 bool includeDisplayInLogs = false;
 bool displayBufferReady = false;
 bool displayUpdateRunning = false;
@@ -1144,6 +1151,12 @@ void setup() {
             mqttSensors["freeHeap"] = [] { return (double)ESP.getFreeHeap(); };
             mqttSensors["maxAllocHeap"] = [] { return (double)heap_caps_get_largest_free_block(MALLOC_CAP_DEFAULT); };
 
+            mqttSensors["maxLoopTime"] = [] {
+                const unsigned long peak = maxLoopTime;
+                maxLoopTime = 0;
+                return (double)peak;
+            };
+
             if (config.get<bool>("hardware.switches.brew.enabled")) {
                 mqttVars["aggbKp"] = "pid.bd.kp";
                 mqttVars["aggbTn"] = "pid.bd.tn";
@@ -1282,6 +1295,19 @@ void setup() {
 }
 
 void loop() {
+    {
+        static unsigned long lastLoopStart = 0;
+        const unsigned long now = millis();
+
+        if (lastLoopStart != 0) {
+            if (const unsigned long duration = now - lastLoopStart; duration > maxLoopTime) {
+                maxLoopTime = duration;
+            }
+        }
+
+        lastLoopStart = now;
+    }
+
     // Accept potential connections for remote logging
     Logger::update();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,6 +16,7 @@
 #include <PID_v1.h>  // for PID calculation
 #include <U8g2lib.h> // i2c display
 #include <WiFiManager.h>
+#include <esp_system.h>
 #include <os.h>
 
 // Includes
@@ -898,12 +899,48 @@ void testTimer(void) {
 
 extern const char sysVersion[] = STR(AUTO_VERSION);
 
+/**
+ * @brief Translate the reset reason into something readable
+ *
+ * Without this the log gives no clue why the machine restarted, which makes a
+ * spontaneous reboot nearly impossible to tell apart from a crash, a watchdog
+ * or a brownout after the fact.
+ */
+static const char* resetReasonToString(const esp_reset_reason_t reason) {
+    switch (reason) {
+        case ESP_RST_POWERON:
+            return "power-on";
+        case ESP_RST_EXT:
+            return "external reset pin";
+        case ESP_RST_SW:
+            return "software restart";
+        case ESP_RST_PANIC:
+            return "panic or unhandled exception";
+        case ESP_RST_INT_WDT:
+            return "interrupt watchdog";
+        case ESP_RST_TASK_WDT:
+            return "task watchdog";
+        case ESP_RST_WDT:
+            return "other watchdog";
+        case ESP_RST_DEEPSLEEP:
+            return "wake from deep sleep";
+        case ESP_RST_BROWNOUT:
+            return "brownout";
+        case ESP_RST_SDIO:
+            return "SDIO";
+        default:
+            return "unknown";
+    }
+}
+
 void setup() {
     // Start serial console
     Serial.begin(115200);
 
     // Initialize the logger
     Logger::init(23);
+
+    LOGF(INFO, "Reset reason: %s", resetReasonToString(esp_reset_reason()));
 
     if (!config.begin()) {
         LOG(ERROR, "Failed to load config from filesystem!");

--- a/src/mqtt.h
+++ b/src/mqtt.h
@@ -521,7 +521,8 @@ inline DiscoveryObject GenerateButtonDevice(const char* name, const char* displa
  * @param device_class
  * @return A `DiscoveryObject` containing the sensor device configuration
  */
-inline DiscoveryObject GenerateSensorDevice(const char* name, const char* displayName, const char* unit_of_measurement, const char* device_class, const std::vector<const char*>& options = {}) {
+inline DiscoveryObject
+GenerateSensorDevice(const char* name, const char* displayName, const char* unit_of_measurement, const char* device_class, const std::vector<const char*>& options = {}, const char* state_class = nullptr) {
     DiscoveryObject sensor_device;
 
     char mqtt_topic[128];
@@ -548,6 +549,14 @@ inline DiscoveryObject GenerateSensorDevice(const char* name, const char* displa
     // drops the sensor. Only set it when we actually have one.
     if (device_class != nullptr && strlen(device_class) > 0) {
         sensorConfigDoc["device_class"] = device_class;
+    }
+
+    // Without a state_class Home Assistant keeps no long-term statistics for a
+    // sensor: values only exist for as long as the recorder retains them (10 days
+    // by default) and cannot be aggregated into hourly min/max/mean. Optional, so
+    // sensors that pass nothing keep their current behaviour.
+    if (state_class != nullptr && strlen(state_class) > 0) {
+        sensorConfigDoc["state_class"] = state_class;
     }
     sensorConfigDoc["payload_available"] = "online";
     sensorConfigDoc["payload_not_available"] = "offline";
@@ -665,8 +674,8 @@ inline int sendHASSIODiscoveryMsg() {
 
     // Always published devices
     failures += publishDiscovery(GenerateSensorDevice("machineState", "Machine State", "", "enum", getMachineStateOptions()));
-    failures += publishDiscovery(GenerateSensorDevice("temperature", "Boiler Temperature", "°C", "temperature"));
-    failures += publishDiscovery(GenerateSensorDevice("heaterPower", "Heater Power", "%", "power_factor"));
+    failures += publishDiscovery(GenerateSensorDevice("temperature", "Boiler Temperature", "°C", "temperature", {}, "measurement"));
+    failures += publishDiscovery(GenerateSensorDevice("heaterPower", "Heater Power", "%", "power_factor", {}, "measurement"));
 
     failures += publishDiscovery(GenerateNumberDevice("brewSetpoint", "Brew setpoint", BREW_SETPOINT_MIN, BREW_SETPOINT_MAX, 0.1, "°C"));
     failures += publishDiscovery(GenerateNumberDevice("steamSetpoint", "Steam setpoint", STEAM_SETPOINT_MIN, STEAM_SETPOINT_MAX, 0.1, "°C"));
@@ -683,7 +692,7 @@ inline int sendHASSIODiscoveryMsg() {
 
     // Conditional devices
     if (config.get<bool>("hardware.switches.brew.enabled")) {
-        failures += publishDiscovery(GenerateSensorDevice("currBrewTime", "Current Brew Time ", "s", "duration"));
+        failures += publishDiscovery(GenerateSensorDevice("currBrewTime", "Current Brew Time ", "s", "duration", {}, "measurement"));
         failures += publishDiscovery(GenerateNumberDevice("brewPidDelay", "Brew Pid Delay", BREW_PID_DELAY_MIN, BREW_PID_DELAY_MAX, 0.1, "s"));
         failures += publishDiscovery(GenerateNumberDevice("targetBrewTime", "Target Brew time", TARGET_BREW_TIME_MIN, TARGET_BREW_TIME_MAX, 0.1, "s"));
         failures += publishDiscovery(GenerateNumberDevice("preinfusion", "Preinfusion filling time", PRE_INFUSION_TIME_MIN, PRE_INFUSION_TIME_MAX, 0.1, "s"));
@@ -695,15 +704,15 @@ inline int sendHASSIODiscoveryMsg() {
     }
 
     if (config.get<bool>("hardware.sensors.scale.enabled")) {
-        failures += publishDiscovery(GenerateSensorDevice("currReadingWeight", "Weight", "g", "weight"));
-        failures += publishDiscovery(GenerateSensorDevice("currBrewWeight", "current Brew Weight", "g", "weight"));
+        failures += publishDiscovery(GenerateSensorDevice("currReadingWeight", "Weight", "g", "weight", {}, "measurement"));
+        failures += publishDiscovery(GenerateSensorDevice("currBrewWeight", "current Brew Weight", "g", "weight", {}, "measurement"));
         failures += publishDiscovery(GenerateButtonDevice("scaleCalibrationOn", "Calibrate Scale"));
         failures += publishDiscovery(GenerateButtonDevice("scaleTareOn", "Tare Scale"));
         failures += publishDiscovery(GenerateNumberDevice("targetBrewWeight", "Brew Weight Target", TARGET_BREW_WEIGHT_MIN, TARGET_BREW_WEIGHT_MAX, 0.1, "g"));
     }
 
     if (config.get<bool>("hardware.sensors.pressure.enabled")) {
-        failures += publishDiscovery(GenerateSensorDevice("pressure", "Pressure", "bar", "pressure"));
+        failures += publishDiscovery(GenerateSensorDevice("pressure", "Pressure", "bar", "pressure", {}, "measurement"));
     }
 
     if (failures > 0) {

--- a/src/mqtt.h
+++ b/src/mqtt.h
@@ -684,6 +684,7 @@ inline int sendHASSIODiscoveryMsg() {
     failures += publishDiscovery(GenerateSensorDevice("freeHeap", "Free Heap", "B", "data_size", {}, "measurement"));
     failures += publishDiscovery(GenerateSensorDevice("maxAllocHeap", "Largest Free Block", "B", "data_size", {}, "measurement"));
     failures += publishDiscovery(GenerateSensorDevice("rssi", "WiFi Signal", "dBm", "signal_strength", {}, "measurement"));
+    failures += publishDiscovery(GenerateSensorDevice("maxLoopTime", "Max Loop Time", "ms", "", {}, "measurement"));
     failures += publishDiscovery(GenerateSensorDevice("temperature", "Boiler Temperature", "°C", "temperature", {}, "measurement"));
     failures += publishDiscovery(GenerateSensorDevice("heaterPower", "Heater Power", "%", "power_factor", {}, "measurement"));
 

--- a/src/mqtt.h
+++ b/src/mqtt.h
@@ -683,6 +683,7 @@ inline int sendHASSIODiscoveryMsg() {
 
     failures += publishDiscovery(GenerateSensorDevice("freeHeap", "Free Heap", "B", "data_size", {}, "measurement"));
     failures += publishDiscovery(GenerateSensorDevice("maxAllocHeap", "Largest Free Block", "B", "data_size", {}, "measurement"));
+    failures += publishDiscovery(GenerateSensorDevice("rssi", "WiFi Signal", "dBm", "signal_strength", {}, "measurement"));
     failures += publishDiscovery(GenerateSensorDevice("temperature", "Boiler Temperature", "°C", "temperature", {}, "measurement"));
     failures += publishDiscovery(GenerateSensorDevice("heaterPower", "Heater Power", "%", "power_factor", {}, "measurement"));
 

--- a/src/mqtt.h
+++ b/src/mqtt.h
@@ -674,6 +674,12 @@ inline int sendHASSIODiscoveryMsg() {
 
     // Always published devices
     failures += publishDiscovery(GenerateSensorDevice("machineState", "Machine State", "", "enum", getMachineStateOptions()));
+    // Why the machine last restarted. Published retained and only from here, i.e. once
+    // per connection: the value never changes while running, and the log line at boot is
+    // unreachable in practice -- the telnet logger keeps no backlog and only serves an
+    // already-connected client, so nobody is listening that early.
+    failures += publishDiscovery(GenerateSensorDevice("resetReason", "Reset Reason", "", ""));
+    mqtt_publish("resetReason", bootResetReasonString(), true);
     failures += publishDiscovery(GenerateSensorDevice("temperature", "Boiler Temperature", "°C", "temperature", {}, "measurement"));
     failures += publishDiscovery(GenerateSensorDevice("heaterPower", "Heater Power", "%", "power_factor", {}, "measurement"));
 

--- a/src/mqtt.h
+++ b/src/mqtt.h
@@ -543,7 +543,12 @@ inline DiscoveryObject GenerateSensorDevice(const char* name, const char* displa
         sensorConfigDoc["unit_of_measurement"] = unit_of_measurement;
     }
 
-    sensorConfigDoc["device_class"] = device_class;
+    // Home Assistant rejects the entire discovery message when device_class is an
+    // empty string ("expected SensorDeviceClass or one of ..."), which silently
+    // drops the sensor. Only set it when we actually have one.
+    if (device_class != nullptr && strlen(device_class) > 0) {
+        sensorConfigDoc["device_class"] = device_class;
+    }
     sensorConfigDoc["payload_available"] = "online";
     sensorConfigDoc["payload_not_available"] = "offline";
     snprintf(topic_buffer, sizeof(topic_buffer), "%s/status", mqtt_topic);

--- a/src/mqtt.h
+++ b/src/mqtt.h
@@ -685,6 +685,7 @@ inline int sendHASSIODiscoveryMsg() {
     failures += publishDiscovery(GenerateSensorDevice("maxAllocHeap", "Largest Free Block", "B", "data_size", {}, "measurement"));
     failures += publishDiscovery(GenerateSensorDevice("rssi", "WiFi Signal", "dBm", "signal_strength", {}, "measurement"));
     failures += publishDiscovery(GenerateSensorDevice("maxLoopTime", "Max Loop Time", "ms", "", {}, "measurement"));
+    failures += publishDiscovery(GenerateSensorDevice("standbyModeTimeRemaining", "Standby Time Remaining", "s", "duration", {}, "measurement"));
     failures += publishDiscovery(GenerateSensorDevice("temperature", "Boiler Temperature", "°C", "temperature", {}, "measurement"));
     failures += publishDiscovery(GenerateSensorDevice("heaterPower", "Heater Power", "%", "power_factor", {}, "measurement"));
 

--- a/src/mqtt.h
+++ b/src/mqtt.h
@@ -681,6 +681,12 @@ inline int sendHASSIODiscoveryMsg() {
     failures += publishDiscovery(GenerateSensorDevice("resetReason", "Reset Reason", "", ""));
     mqtt_publish("resetReason", bootResetReasonString(), true);
 
+    // Panic details from the stored core dump, or "none". Retained for the same
+    // reason as the reset reason above -- it is a boot-time value, and nobody is
+    // watching a log that early.
+    failures += publishDiscovery(GenerateSensorDevice("crashInfo", "Last Crash", "", ""));
+    mqtt_publish("crashInfo", bootCrashInfoString(), true);
+
     failures += publishDiscovery(GenerateSensorDevice("freeHeap", "Free Heap", "B", "data_size", {}, "measurement"));
     failures += publishDiscovery(GenerateSensorDevice("maxAllocHeap", "Largest Free Block", "B", "data_size", {}, "measurement"));
     failures += publishDiscovery(GenerateSensorDevice("rssi", "WiFi Signal", "dBm", "signal_strength", {}, "measurement"));

--- a/src/mqtt.h
+++ b/src/mqtt.h
@@ -680,6 +680,9 @@ inline int sendHASSIODiscoveryMsg() {
     // already-connected client, so nobody is listening that early.
     failures += publishDiscovery(GenerateSensorDevice("resetReason", "Reset Reason", "", ""));
     mqtt_publish("resetReason", bootResetReasonString(), true);
+
+    failures += publishDiscovery(GenerateSensorDevice("freeHeap", "Free Heap", "B", "data_size", {}, "measurement"));
+    failures += publishDiscovery(GenerateSensorDevice("maxAllocHeap", "Largest Free Block", "B", "data_size", {}, "measurement"));
     failures += publishDiscovery(GenerateSensorDevice("temperature", "Boiler Temperature", "°C", "temperature", {}, "measurement"));
     failures += publishDiscovery(GenerateSensorDevice("heaterPower", "Heater Power", "%", "power_factor", {}, "measurement"));
 

--- a/src/powerHandler.h
+++ b/src/powerHandler.h
@@ -45,6 +45,7 @@ inline void checkPowerSwitch() {
             }
             else {
                 if (machineState != kStandby) {
+                    LOG(INFO, "Power switch turned off, entering standby");
                     performSafeShutdown();
                     machineState = kStandby;
                     standbyModeRemainingTimeMillis = 0;
@@ -74,6 +75,7 @@ inline void checkPowerSwitch() {
                     }
                 }
                 else {
+                    LOG(INFO, "Power button pressed, entering standby");
                     performSafeShutdown();
                     machineState = kStandby;
                     standbyModeRemainingTimeMillis = 0;


### PR DESCRIPTION
As you might have noticed, I already ran into quite a number of issues on my machine, and during debugging sessions I added a bunch of improved diagnostics which might also be useful for others.

## New MQTT topics

A number of new MQTT Topics which allow a first diagnosis via HA. Most of these are inspired by ESPHome which also publishes most of these values to HA.

| Topic | Unit | device_class | state_class | Notes |
|---|---|---|---|---|
| `resetReason` | | | | Why the machine last booted, as text. Retained, published once per connection |
| `crashInfo` | | | | Task, exception cause, PC and faulting address of the last stored core dump, or `none`. Retained |
| `freeHeap` | B | `data_size` | `measurement` | |
| `maxAllocHeap` | B | `data_size` | `measurement` | Largest allocatable block. Together with `freeHeap` this separates fragmentation from a leak |
| `rssi` | dBm | `signal_strength` | `measurement` | |
| `maxLoopTime` | ms | | `measurement` | Worst-case duration of a loop pass. Read-and-reset, so each publish is the peak since the previous one |
| `standbyModeTimeRemaining` | s | `duration` | `measurement` | Already published to its topic before this branch, it just had no discovery message |

`resetReason` and `crashInfo` are text and carry no `device_class`, which is why the empty-`device_class` fix is needed.

Existing sensors keep their topics and payloads and only gain `state_class: measurement`, so Home Assistant starts keeping long-term statistics for them: `temperature`, `heaterPower`, `currBrewTime`, `currReadingWeight`, `currBrewWeight`, `pressure`.

## Log messages

```
Reset reason: <power-on | software restart | panic or unhandled exception | ...>
Core dump found: task=async_tcp cause=29 pc=0x4008435d vaddr=0x00000000
Power switch turned off, entering standby
Power button pressed, entering standby
```

The reset reason distinguishes a crash from the harmless cases, and the power switch's long-press reboot reports `software restart`.

The two standby lines close a gap. `kStandby` is reachable either through the timer expiring or through the power switch, and only the timer said so (`updateStandbyTimer` logs `Entering standby mode...`). A machine found in standby could not be explained from the log, which is exactly what I ran into.

## Core dump

The partition table already reserves a coredump partition and the Arduino sdkconfig enables `CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH` with the ELF format, so after a panic the crashing task, the cause, the PC and the backtrace are sitting in flash. Nothing ever read them back.

`crashInfo` carries the triage part over MQTT: task, cause, PC and faulting address.
For the full picture there is `/download/coredump`, which streams the raw dump out of the partition in chunks. Analyse it offline:

```
esp-coredump info_corefile --core dump.bin --core-format raw firmware.elf
```

Gated by `authenticate()`, same as the config download. The dump is deliberately not erased after reading, so it survives reboots and updates. That means `crashInfo` describes the last panic and not necessarily the last boot, which is why it is worth reading together with `resetReason`.

## Notes for review

The two discovery commits come first on purpose. The sensor commits pass the new `state_class` argument, so in any other order the intermediate commits would not compile. All 11 commits were built individually to check that.

`maxLoopTime` on a healthy machine sits at a few tens of milliseconds, dominated by the display update.
